### PR TITLE
Fix issue with tty.* ports on mac os

### DIFF
--- a/lib/rubyserial/posix.rb
+++ b/lib/rubyserial/posix.rb
@@ -2,7 +2,7 @@ require 'ffi'
 
 class Serial
   def initialize(address, baude_rate=9600, data_bits=8)
-    file_opts = RubySerial::Posix::O_RDWR | RubySerial::Posix::O_NOCTTY
+    file_opts = RubySerial::Posix::O_RDWR | RubySerial::Posix::O_NOCTTY | RubySerial::Posix::O_NONBLOCK
     @fd = RubySerial::Posix.open(address, file_opts)
 
     if @fd == -1


### PR DESCRIPTION
This fixes the issue where some `tty.*` serial ports would not work correctly on mac os x. This should resolve that issue and work with all `cu.*` and `tty.*` serial ports.
