### PR TITLE
Allow enabling parity on posix systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ The interface to RubySerial should be (mostly) compatible with other Ruby serial
 
 ```ruby
 require 'rubyserial'
+serialport = Serial.new '/dev/ttyACM0' # Defaults to 9600 baud, 8 data bits, and no parity
 serialport = Serial.new '/dev/ttyACM0', 57600
+serialport = Serial.new '/dev/ttyACM0', 19200, 8, :even
 ```
 
 ## Methods

--- a/lib/rubyserial.rb
+++ b/lib/rubyserial.rb
@@ -2,18 +2,19 @@
 
 require 'rbconfig'
 require 'ffi'
-include RbConfig
 
 module RubySerial
+  ON_WINDOWS = RbConfig::CONFIG['host_os'] =~ /mswin|windows|mingw/i
+  ON_LINUX = RbConfig::CONFIG['host_os'] =~ /linux/i
   class Exception < Exception
   end
 end
 
-if CONFIG['host_os'] =~ /mswin|windows|mingw/i
+if RubySerial::ON_WINDOWS
   require 'rubyserial/windows_constants'
   require 'rubyserial/windows'
 else
-  if CONFIG['host_os'] =~ /linux/i
+  if RubySerial::ON_LINUX
     require 'rubyserial/linux_constants'
   else
     require 'rubyserial/osx_constants'

--- a/lib/rubyserial/linux_constants.rb
+++ b/lib/rubyserial/linux_constants.rb
@@ -14,6 +14,8 @@ module RubySerial
     TCSANOW = 0
     TCSETS = 0x5402
     IGNPAR = 0000004
+    PARENB = 0000400
+    PARODD = 0001000
     CREAD = 0000200
     CLOCAL = 0004000
     VMIN = 6
@@ -58,6 +60,12 @@ module RubySerial
       3000000 => 0010015,
       3500000 => 0010016,
       4000000 => 0010017
+    }
+
+    PARITY = {
+      :none => 0000000,
+      :even => PARENB,
+      :odd => PARENB | PARODD,
     }
 
     ERROR_CODES = {

--- a/lib/rubyserial/osx_constants.rb
+++ b/lib/rubyserial/osx_constants.rb
@@ -11,6 +11,8 @@ module RubySerial
     F_GETFL = 3
     F_SETFL = 4
     IGNPAR = 0x00000004
+    PARENB = 0x00001000
+    PARODD = 0x00002000
     VMIN = 16
     VTIME = 17
     CLOCAL = 0x00008000
@@ -49,6 +51,12 @@ module RubySerial
       76800 => 76800,
       115200 => 115200,
       230400 => 230400
+    }
+
+    PARITY = {
+      :none => 0x00000000,
+      :even => PARENB,
+      :odd => PARENB | PARODD,
     }
 
     ERROR_CODES = {

--- a/lib/rubyserial/posix.rb
+++ b/lib/rubyserial/posix.rb
@@ -1,7 +1,7 @@
 # Copyright (c) 2014-2016 The Hybrid Group
 
 class Serial
-  def initialize(address, baude_rate=9600, data_bits=8)
+  def initialize(address, baude_rate=9600, data_bits=8, parity=:none)
     file_opts = RubySerial::Posix::O_RDWR | RubySerial::Posix::O_NOCTTY | RubySerial::Posix::O_NONBLOCK
     @fd = RubySerial::Posix.open(address, file_opts)
 
@@ -21,7 +21,7 @@ class Serial
       raise RubySerial::Exception, RubySerial::Posix::ERROR_CODES[FFI.errno]
     end
 
-    @config = build_config(baude_rate, data_bits)
+    @config = build_config(baude_rate, data_bits, parity)
 
     err = RubySerial::Posix.tcsetattr(@fd, RubySerial::Posix::TCSANOW, @config)
     if err == -1
@@ -108,7 +108,7 @@ class Serial
     bytes.map { |e| e.chr }.join
   end
 
-  def build_config(baude_rate, data_bits)
+  def build_config(baude_rate, data_bits, parity)
     config = RubySerial::Posix::Termios.new
 
     config[:c_iflag]  = RubySerial::Posix::IGNPAR
@@ -117,7 +117,8 @@ class Serial
     config[:c_cflag]  = RubySerial::Posix::DATA_BITS[data_bits] |
       RubySerial::Posix::CREAD |
       RubySerial::Posix::CLOCAL |
-      RubySerial::Posix::BAUDE_RATES[baude_rate]
+      RubySerial::Posix::BAUDE_RATES[baude_rate] |
+      RubySerial::Posix::PARITY[parity]
 
     config[:cc_c][RubySerial::Posix::VMIN] = 0
 

--- a/lib/rubyserial/windows.rb
+++ b/lib/rubyserial/windows.rb
@@ -1,7 +1,10 @@
 # Copyright (c) 2014-2016 The Hybrid Group
 
 class Serial
-  def initialize(address, baude_rate=9600, data_bits=8)
+  def initialize(address, baude_rate=9600, data_bits=8, parity=:none)
+    if parity != :none
+      warn "warning: parity #{parity} is not supported on Windows.  Ignoring."
+    end
     file_opts = RubySerial::Win32::GENERIC_READ | RubySerial::Win32::GENERIC_WRITE
     @fd = RubySerial::Win32.CreateFileA("\\\\.\\#{address}", file_opts, 0, nil, RubySerial::Win32::OPEN_EXISTING, 0, nil)
     err = FFI.errno

--- a/spec/rubyserial_spec.rb
+++ b/spec/rubyserial_spec.rb
@@ -3,8 +3,7 @@ require 'rubyserial'
 describe "rubyserial" do
   before do
     @ports = []
-    require 'rbconfig'
-    if RbConfig::CONFIG['host_os'] =~ /mswin|windows|mingw/i
+    if RubySerial::ON_WINDOWS
       # NOTE: Tests on windows require com0com
       # https://github.com/hybridgroup/rubyserial/raw/appveyor_deps/setup_com0com_W7_x64_signed.exe
       @ports[0] = "\\\\.\\CNCA0"
@@ -128,6 +127,26 @@ describe "rubyserial" do
       @sp.write("Something \n Something else \n\n and other stuff")
       sleep 0.1
       expect(@sp2.gets('')).to eql("Something \n Something else \n\n")
+    end
+  end
+
+  describe 'config' do
+    it 'should accept EVEN parity' do
+      @sp2.close
+      @sp.close
+      @sp2 = Serial.new(@ports[0], 19200, 8, :even)
+      @sp = Serial.new(@ports[1], 19200, 8, :even)
+      @sp.write("Hello!\n")
+      expect(@sp2.gets).to eql("Hello!\n")
+    end
+
+    it 'should accept ODD parity' do
+      @sp2.close
+      @sp.close
+      @sp2 = Serial.new(@ports[0], 19200, 8, :odd)
+      @sp = Serial.new(@ports[1], 19200, 8, :odd)
+      @sp.write("Hello!\n")
+      expect(@sp2.gets).to eql("Hello!\n")
     end
   end
 end


### PR DESCRIPTION
We use rubyserial with RS485 where EVEN parity is enabled.  With the changes in this PR, it works well on both OS X and Linux (on a Raspberry PI 3).

I don't have any documentation for Windows, so I have not added the feature there.  I added a warning if someone tries to use parity on Windows.

I added a spec for using the parity option.

Finally I updated the README with usage for parity and listed the default.

Hopefully this can be merged and released 😄 .
