### PR TITLE
Remove testing of Ruby 1.9.3 and 2.0 and add testing of Ruby 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0
-  - 2.1
+  - 2.3.1
   - 2.2
-  - ruby-head
-  - jruby
-  - jruby-head
+  - 2.1
+  - jruby-9.1.2.0
   - rbx-2
+  - ruby-head
+  - jruby-head
 matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
 before_install:
-  - gem update bundler
+  - gem query -i -n ^bundler$ -v'>=1.12.5' >/dev/null || gem install bundler
 install:
   - sudo apt-get update && sudo apt-get install --force-yes socat
 script:


### PR DESCRIPTION
Update JRuby testing to JRuby 9K
https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended
https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1