### PR TITLE
Rename RubySerial::Exception to RubySerial::Error and inherit from IOError

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,22 +28,22 @@ serialport = Serial.new '/dev/ttyACM0', 19200, 8, :even
 **write(data : String) -> Int**
 
 Returns the number of bytes written.
-Emits a `RubySerial::Exception` on error.
+Emits a `RubySerial::Error` on error.
 
 **read(length : Int) -> String**
 
 Returns a string up to `length` long. It is not guaranteed to return the entire
 length specified, and will return an empty string if no data is
-available. Emits a `RubySerial::Exception` on error.
+available. Emits a `RubySerial::Error` on error.
 
 **getbyte -> Fixnum or nil**
 
 Returns an 8 bit byte or nil if no data is available.
-Emits a `RubySerial::Exception` on error.
+Emits a `RubySerial::Error` on error.
 
-**RubySerial::Exception**
+**RubySerial::Error**
 
-A wrapper exception type, that returns the underlying system error code.
+A wrapper error type that returns the underlying system error code and inherits from IOError.
 
 ## Running the tests
 

--- a/lib/rubyserial.rb
+++ b/lib/rubyserial.rb
@@ -6,7 +6,7 @@ require 'ffi'
 module RubySerial
   ON_WINDOWS = RbConfig::CONFIG['host_os'] =~ /mswin|windows|mingw/i
   ON_LINUX = RbConfig::CONFIG['host_os'] =~ /linux/i
-  class Exception < Exception
+  class Error < IOError
   end
 end
 

--- a/lib/rubyserial/posix.rb
+++ b/lib/rubyserial/posix.rb
@@ -6,26 +6,26 @@ class Serial
     @fd = RubySerial::Posix.open(address, file_opts)
 
     if @fd == -1
-      raise RubySerial::Exception, RubySerial::Posix::ERROR_CODES[FFI.errno]
+      raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
     else
       @open = true
     end
 
     fl = RubySerial::Posix.fcntl(@fd, RubySerial::Posix::F_GETFL, :int, 0)
     if fl == -1
-      raise RubySerial::Exception, RubySerial::Posix::ERROR_CODES[FFI.errno]
+      raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
     end
 
     err = RubySerial::Posix.fcntl(@fd, RubySerial::Posix::F_SETFL, :int, ~RubySerial::Posix::O_NONBLOCK & fl)
     if err == -1
-      raise RubySerial::Exception, RubySerial::Posix::ERROR_CODES[FFI.errno]
+      raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
     end
 
     @config = build_config(baude_rate, data_bits, parity)
 
     err = RubySerial::Posix.tcsetattr(@fd, RubySerial::Posix::TCSANOW, @config)
     if err == -1
-      raise RubySerial::Exception, RubySerial::Posix::ERROR_CODES[FFI.errno]
+      raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
     end
   end
 
@@ -36,7 +36,7 @@ class Serial
   def close
     err = RubySerial::Posix.close(@fd)
     if err == -1
-      raise RubySerial::Exception, RubySerial::Posix::ERROR_CODES[FFI.errno]
+      raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
     else
       @open = false
     end
@@ -49,7 +49,7 @@ class Serial
       buff = FFI::MemoryPointer.from_string(data[n..-1].to_s)
       i = RubySerial::Posix.write(@fd, buff, buff.size-1)
       if i == -1
-        raise RubySerial::Exception, RubySerial::Posix::ERROR_CODES[FFI.errno]
+        raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
       else
         n = n+i
       end
@@ -63,7 +63,7 @@ class Serial
     buff = FFI::MemoryPointer.new :char, size
     i = RubySerial::Posix.read(@fd, buff, size)
     if i == -1
-      raise RubySerial::Exception, RubySerial::Posix::ERROR_CODES[FFI.errno]
+      raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
     end
     buff.get_bytes(0, i)
   end
@@ -72,7 +72,7 @@ class Serial
     buff = FFI::MemoryPointer.new :char, 1
     i = RubySerial::Posix.read(@fd, buff, 1)
     if i == -1
-      raise RubySerial::Exception, RubySerial::Posix::ERROR_CODES[FFI.errno]
+      raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
     end
 
     if i == 0

--- a/lib/rubyserial/windows.rb
+++ b/lib/rubyserial/windows.rb
@@ -9,7 +9,7 @@ class Serial
     @fd = RubySerial::Win32.CreateFileA("\\\\.\\#{address}", file_opts, 0, nil, RubySerial::Win32::OPEN_EXISTING, 0, nil)
     err = FFI.errno
     if err != 0
-      raise RubySerial::Exception, RubySerial::Win32::ERROR_CODES[err]
+      raise RubySerial::Error, RubySerial::Win32::ERROR_CODES[err]
     else
       @open = true
     end
@@ -18,7 +18,7 @@ class Serial
       dcb[:dcblength] = RubySerial::Win32::DCB::Sizeof
       err = RubySerial::Win32.GetCommState @fd, dcb
       if err == 0
-        raise RubySerial::Exception, RubySerial::Win32::ERROR_CODES[FFI.errno]
+        raise RubySerial::Error, RubySerial::Win32::ERROR_CODES[FFI.errno]
       end
       dcb[:baudrate] = baude_rate
       dcb[:bytesize] = data_bits
@@ -26,7 +26,7 @@ class Serial
       dcb[:parity]   = RubySerial::Win32::DCB::NOPARITY
       err = RubySerial::Win32.SetCommState @fd, dcb
       if err == 0
-        raise RubySerial::Exception, RubySerial::Win32::ERROR_CODES[FFI.errno]
+        raise RubySerial::Error, RubySerial::Win32::ERROR_CODES[FFI.errno]
       end
     end
 
@@ -38,7 +38,7 @@ class Serial
       timeouts[:write_total_timeout_constant]   = 10
       err = RubySerial::Win32.SetCommTimeouts @fd, timeouts
       if err == 0
-        raise RubySerial::Exception, RubySerial::Win32::ERROR_CODES[FFI.errno]
+        raise RubySerial::Error, RubySerial::Win32::ERROR_CODES[FFI.errno]
       end
     end
   end
@@ -48,7 +48,7 @@ class Serial
     count = FFI::MemoryPointer.new :uint32, 1
     err = RubySerial::Win32.ReadFile(@fd, buff, size, count, nil)
     if err == 0
-      raise RubySerial::Exception, RubySerial::Win32::ERROR_CODES[FFI.errno]
+      raise RubySerial::Error, RubySerial::Win32::ERROR_CODES[FFI.errno]
     end
     buff.get_bytes(0, count.read_int)
   end
@@ -58,7 +58,7 @@ class Serial
     count = FFI::MemoryPointer.new :uint32, 1
     err = RubySerial::Win32.ReadFile(@fd, buff, 1, count, nil)
     if err == 0
-      raise RubySerial::Exception, RubySerial::Win32::ERROR_CODES[FFI.errno]
+      raise RubySerial::Error, RubySerial::Win32::ERROR_CODES[FFI.errno]
     end
 
     if count.read_int == 0
@@ -73,7 +73,7 @@ class Serial
     count = FFI::MemoryPointer.new :uint32, 1
     err = RubySerial::Win32.WriteFile(@fd, buff, buff.size-1, count, nil)
     if err == 0
-      raise RubySerial::Exception, RubySerial::Win32::ERROR_CODES[FFI.errno]
+      raise RubySerial::Error, RubySerial::Win32::ERROR_CODES[FFI.errno]
     end
     count.read_int
   end
@@ -91,7 +91,7 @@ class Serial
   def close
     err = RubySerial::Win32.CloseHandle(@fd)
     if err == 0
-      raise RubySerial::Exception, RubySerial::Win32::ERROR_CODES[FFI.errno]
+      raise RubySerial::Error, RubySerial::Win32::ERROR_CODES[FFI.errno]
     else
       @open = false
     end


### PR DESCRIPTION
This fixes hybridgroup/rubyserial#31