### PR TITLE
Add support for MSYS2

### DIFF
--- a/lib/rubyserial.rb
+++ b/lib/rubyserial.rb
@@ -4,7 +4,7 @@ require 'rbconfig'
 require 'ffi'
 
 module RubySerial
-  ON_WINDOWS = RbConfig::CONFIG['host_os'] =~ /mswin|windows|mingw/i
+  ON_WINDOWS = RbConfig::CONFIG['host_os'] =~ /mswin|windows|mingw|msys/i
   ON_LINUX = RbConfig::CONFIG['host_os'] =~ /linux/i
   class Exception < Exception
   end


### PR DESCRIPTION
This allows the library to recognize MSYS2 as a Windows environment.  It requires a patched FFI gem that also recognizes MSYS2 otherwise it will fail to load the kernel32 library.