### PR TITLE
Release the GVL while calls to C code

### DIFF
--- a/lib/rubyserial/linux_constants.rb
+++ b/lib/rubyserial/linux_constants.rb
@@ -211,12 +211,12 @@ module RubySerial
               :c_ospeed, :uint
     end
 
-    attach_function :ioctl, [ :int, :ulong, RubySerial::Posix::Termios], :int
-    attach_function :tcsetattr, [ :int, :int, RubySerial::Posix::Termios ], :int
-    attach_function :fcntl, [:int, :int, :varargs], :int
-    attach_function :open, [:pointer, :int], :int
-    attach_function :close, [:int], :int
-    attach_function :write, [:int, :pointer,  :int],:int
-    attach_function :read, [:int, :pointer,  :int],:int
+    attach_function :ioctl, [ :int, :ulong, RubySerial::Posix::Termios], :int, blocking: true
+    attach_function :tcsetattr, [ :int, :int, RubySerial::Posix::Termios ], :int, blocking: true
+    attach_function :fcntl, [:int, :int, :varargs], :int, blocking: true
+    attach_function :open, [:pointer, :int], :int, blocking: true
+    attach_function :close, [:int], :int, blocking: true
+    attach_function :write, [:int, :pointer,  :int],:int, blocking: true
+    attach_function :read, [:int, :pointer,  :int],:int, blocking: true
   end
 end

--- a/lib/rubyserial/osx_constants.rb
+++ b/lib/rubyserial/osx_constants.rb
@@ -179,11 +179,11 @@ module RubySerial
               :c_ospeed, :ulong
     end
 
-    attach_function :tcsetattr, [ :int, :int, RubySerial::Posix::Termios ], :int
-    attach_function :fcntl, [:int, :int, :varargs], :int
-    attach_function :open, [:pointer, :int], :int
-    attach_function :close, [:int], :int
-    attach_function :write, [:int, :pointer,  :int],:int
-    attach_function :read, [:int, :pointer,  :int],:int
+    attach_function :tcsetattr, [ :int, :int, RubySerial::Posix::Termios ], :int, blocking: true
+    attach_function :fcntl, [:int, :int, :varargs], :int, blocking: true
+    attach_function :open, [:pointer, :int], :int, blocking: true
+    attach_function :close, [:int], :int, blocking: true
+    attach_function :write, [:int, :pointer,  :int],:int, blocking: true
+    attach_function :read, [:int, :pointer,  :int],:int, blocking: true
   end
 end

--- a/lib/rubyserial/windows_constants.rb
+++ b/lib/rubyserial/windows_constants.rb
@@ -263,13 +263,13 @@ module RubySerial
               :write_total_timeout_constant,    :uint32
     end
 
-    attach_function :CreateFileA,     [:pointer, :uint32, :uint32, :pointer, :uint32, :uint32, :pointer], :pointer
-    attach_function :CloseHandle,     [:pointer], :int
-    attach_function :ReadFile,        [:pointer, :pointer, :uint32, :pointer, :pointer], :int32
-    attach_function :WriteFile,       [:pointer, :pointer, :uint32, :pointer, :pointer], :int32
-    attach_function :GetCommState,    [:pointer, RubySerial::Win32::DCB], :int32
-    attach_function :SetCommState,    [:pointer, RubySerial::Win32::DCB], :int32
-    attach_function :GetCommTimeouts, [:pointer, RubySerial::Win32::CommTimeouts], :int32
-    attach_function :SetCommTimeouts, [:pointer, RubySerial::Win32::CommTimeouts], :int32
+    attach_function :CreateFileA,     [:pointer, :uint32, :uint32, :pointer, :uint32, :uint32, :pointer], :pointer, blocking: true
+    attach_function :CloseHandle,     [:pointer], :int, blocking: true
+    attach_function :ReadFile,        [:pointer, :pointer, :uint32, :pointer, :pointer], :int32, blocking: true
+    attach_function :WriteFile,       [:pointer, :pointer, :uint32, :pointer, :pointer], :int32, blocking: true
+    attach_function :GetCommState,    [:pointer, RubySerial::Win32::DCB], :int32, blocking: true
+    attach_function :SetCommState,    [:pointer, RubySerial::Win32::DCB], :int32, blocking: true
+    attach_function :GetCommTimeouts, [:pointer, RubySerial::Win32::CommTimeouts], :int32, blocking: true
+    attach_function :SetCommTimeouts, [:pointer, RubySerial::Win32::CommTimeouts], :int32, blocking: true
   end
 end


### PR DESCRIPTION
FFI defaults to not release the GVL while calls to C code (in contrast to Fiddle). This blocks other Ruby threads for the time of the call. It also slows simultanous communication down, when running over several TTY's in parallel.

The negative performance impact of releasing the GVL is so small, that it doesn't matter compared to the slowness of RS232. However the positive performance impact when running multiple threads is huge: In my case with 16 devices releasing GVL drops the time for one particular operation from 160 to 23 seconds.
