### PR TITLE
Don’t mask baud into c_cflag on Mac. Prevents output on RTS at 115200.

### DIFF
--- a/lib/rubyserial/osx_constants.rb
+++ b/lib/rubyserial/osx_constants.rb
@@ -17,6 +17,7 @@ module RubySerial
     VTIME = 17
     CLOCAL = 0x00008000
     CREAD = 0x00000800
+    CCTS_OFLOW = 0x00010000 # Clearing this disables RTS AND CTS.
     TCSANOW = 0
     NCCS = 20
 

--- a/lib/rubyserial/posix.rb
+++ b/lib/rubyserial/posix.rb
@@ -117,8 +117,12 @@ class Serial
     config[:c_cflag]  = RubySerial::Posix::DATA_BITS[data_bits] |
       RubySerial::Posix::CREAD |
       RubySerial::Posix::CLOCAL |
-      RubySerial::Posix::BAUDE_RATES[baude_rate] |
       RubySerial::Posix::PARITY[parity]
+
+    # Masking in baud rate on OS X would corrupt the settings.
+    if RubySerial::ON_LINUX
+      config[:c_cflag] = config[:c_cflag] | RubySerial::Posix::BAUDE_RATES[baude_rate]
+    end
 
     config[:cc_c][RubySerial::Posix::VMIN] = 0
 


### PR DESCRIPTION
After failing to get my ESP8266 NodeMCU board working with `rubyserial` on OS X, I noticed it worked fine with `ser2net` and the `-RTSCTS` flag. The dev board has the RTS pin of the USB UART connected to the the ESP8266 GPIO0 which is held low to put it into flashing mode. `rubyserial` does this for some reason when it connects.

After digging around in some `termios` source files for Darwin, I figured out that I need to clear bit 0x10000 from `c_cflag` to get the equivalent of the `ser2net` behavior. After trying to figure out where that bit was being set in the first place, and why it was defaulting to ON, I realized it was coming from OR-ing the baud rate (115200 in my case) into `c_cflag`. The most significant bit of 115200 converted to binary is the same bit in question.

I could be wrong about this, but I don't think the baud rates are supposed to be masked into `c_cflag` the way they are for Linux. In `osx_constants.rb` each baud rate maps back to itself as an integer. Compare this to Linux where the last 4 bits of `c_cflag` map to specific baud rates, and one other bit is a flag to access higher values. For OS X, bits that would control settings overlap with bits that would set the baud rate. Doesn't seem right at all.

The fix in this PR solves my problem where the RTS pin was being toggled, so the NodeMCU works over its built in USB port now and, as far as I can tell, doesn't break any functionality.