### PR TITLE
Implemented ioctl call to set custom baud rate on OSX

### DIFF
--- a/lib/rubyserial/osx_constants.rb
+++ b/lib/rubyserial/osx_constants.rb
@@ -21,6 +21,7 @@ module RubySerial
     CCTS_OFLOW = 0x00010000 # Clearing this disables RTS AND CTS.
     TCSANOW = 0
     NCCS = 20
+    IOSSIOSPEED = 0x80045402 # ioctl request for OSX custom baud rate
 
     DATA_BITS = {
       5 => 0x00000000,
@@ -188,6 +189,7 @@ module RubySerial
 
     attach_function :tcsetattr, [ :int, :int, RubySerial::Posix::Termios ], :int, blocking: true
     attach_function :fcntl, [:int, :int, :varargs], :int, blocking: true
+    attach_function :ioctl, [:int, :ulong, :pointer], :int, blocking: true
     attach_function :open, [:pointer, :int], :int, blocking: true
     attach_function :close, [:int], :int, blocking: true
     attach_function :write, [:int, :pointer,  :int],:int, blocking: true


### PR DESCRIPTION
On OSX it is impossible to set baud rates higher than standard using `tcsetattr`. Attempting to do so will throw an `EINVAL` error.
However, it is possible to set arbitrary baud rates using `ioctl` call.
Example can be found [here](https://developer.apple.com/library/archive/samplecode/SerialPortSample/Listings/SerialPortSample_SerialPortSample_c.html#//apple_ref/doc/uid/DTS10000454-SerialPortSample_SerialPortSample_c-DontLinkElementID_4)

This PR attaches ioctl and in case of undefined baud rate on OSX attempts to set speed using that call.
The only caveat here is that I have been unable to write tests for it due to pty's opened by socat not supporting setting speed at all. ioctl throws ENOTTY when attempted.
On real hardware it works well though (needed these changes for my arduino project). Not sure what we can do about it.
