### PR TITLE
Use native IO objects & support blocking IO

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,22 @@ The interface to RubySerial should be compatible with other Ruby serialport gems
 ```ruby
 require 'rubyserial'
 
-# 0.6 API (nonblocking by default)
+# 0.6 API (nonblocking IO by default)
 serialport = Serial.new '/dev/ttyACM0' # Defaults to 9600 baud, 8 data bits, and no parity
 serialport = Serial.new '/dev/ttyACM0', 57600
 serialport = Serial.new '/dev/ttyACM0', 19200, :even, 8
 serialport = Serial.new '/dev/ttyACM0', 19200, :even, 8, true # to enable blocking IO
 
-# SerialPort gem compatible API (blocking IO by default)
+# SerialPort gem compatible API (blocking & nonblocking IO)
 serialport = SerialPort.new '/dev/ttyACM0' # Defaults to the existing system settings.
 serialport = SerialPort.new '/dev/ttyACM0', 57600
 serialport = SerialPort.new '/dev/ttyACM0', 19200, 8, :even # note the order of args is different
 
 # open style syntax
 SerialPort.open '/dev/ttyACM0', 19200, 8, :even do |serialport|
+	serialport.read(3) # blocking
+	serialport.read_nonblock(3) # nonblocking
+	serialport.readpartial(3) # nonblocking after blocking for first character
 	# ...
 end
 
@@ -46,7 +49,7 @@ five = SerialPort.open '/dev/ttyACM0' do |serialport|
 	5
 end
 ```
-Both SerialPort and Serial are an IO object, so standard methods like read and write are available, but do note that Serial has some nonstandard read behavior by default.
+Both SerialPort and Serial are an IO object, so standard methods like read and write are available, but do note that Serial has some nonstandard read behavior by default. See the documentation for details
 
 ## Classes
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ RubySerial is a simple Ruby gem for reading from and writing to serial ports.
 
 Unlike other Ruby serial port implementations, it supports all of the most popular Ruby implementations (MRI, JRuby, & Rubinius) on the most popular operating systems (OSX, Linux, & Windows). And it does not require any native compilation thanks to using RubyFFI [https://github.com/ffi/ffi](https://github.com/ffi/ffi).
 
-The interface to RubySerial should be (mostly) compatible with other Ruby serialport gems, so you should be able to drop in the new gem, change the `require` and use it as a replacement. If not, please let us know so we can address any issues.
+The interface to RubySerial should be compatible with other Ruby serialport gems, so you should be able to drop in the new gem, change the `require` and use it as a replacement. If not, please let us know so we can address any issues.
 
 [![Build Status](https://travis-ci.org/hybridgroup/rubyserial.svg)](https://travis-ci.org/hybridgroup/rubyserial)
 [![Build status](https://ci.appveyor.com/api/projects/status/946nlaqy4443vb99/branch/master?svg=true)](https://ci.appveyor.com/project/zankich/rubyserial/branch/master)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The medium level API with {SerialIO} also returns an IO object, but allows you t
 
 The low level API is not considered stable, and may change in minor releases.
 
-See the documentation ! TODO link!!! for more details
+See the yard documentation for more details
 
 **RubySerial::Error**
 
@@ -73,7 +73,12 @@ A wrapper error type that returns the underlying system error code and inherits 
 
 ## Running the tests
 
-The test suite is written using rspec, just use the `rspec` command. There are 3 test files: SerialPort API comatibility `serialport_spec`, Serial API compatability `rubyserial_spec`, and the DTR & timeout correctness test suite `serial_arduino_spec`. The latter requires this !TODO! program flashed to an arduino, or a compatible program that the test can talk to. 
+The test suite is written using rspec, just use the `rspec` command. There are 3 test files: SerialPort API compatibility `serialport_spec`, Serial API compatability `rubyserial_spec`, and the DTR & timeout correctness test suite `serial_arduino_spec`. The latter requires the `spec/arduino.ino` program flashed to an arduino, or a compatible program that the test can talk to. If you wish to test either of the latter, define the enviroment variable `RS_ARDUINO_PORT` to be the arduino serial port. If you wish to run `serialport_spec`, either the `RS_ARDUINO_PORT` or `RS_TEST_PORT` must be defined.
+
+```txt
+$ export RS_ARDUINO_PORT=/dev/ttyUSB0
+$ rspec
+```
 
 ### Test dependencies
 

--- a/lib/rubyserial.rb
+++ b/lib/rubyserial.rb
@@ -268,7 +268,7 @@ class Serial < SerialIO
         stop_bits: stop_bits,
         enable_blocking: enable_blocking,
         clear_config: true), Serial).tap do |this|
-      this.instance_variable_set :@nonblock_mac, (RubySerial::ON_MAC && !enable_blocking)
+      this.instance_variable_set :@nonblock_mac, (!RubySerial::ON_LINUX && !enable_blocking)
     end
   end
 

--- a/lib/rubyserial.rb
+++ b/lib/rubyserial.rb
@@ -88,6 +88,10 @@ class SerialPort < IO
   #
   # @overload new(device, hash)
   #   @param [Hash<String, Object>] hash The given parameters, but as stringly-keyed values in a hash
+  #   @option hash [Integer] "baud" The baud. Optional
+  #   @option hash [Integer] "data_bits" The number of data bits. Optional
+  #   @option hash [Integer] "stop" The number of stop bits. Optional
+  #   @option hash [Symbol] "parity" The parity. Optional
   def self.new(device, *params)
     raise ArgumentError, "Not Implemented. Please use a full path #{device}" if device.is_a? Integer
     baud, *listargs = *params
@@ -139,6 +143,10 @@ class SerialPort < IO
   #   Creates a new {SerialPort} and returns it.
   #   @return [SerialPort] An opened serial port
   #   @param [Hash<String, Object>] hash The given parameters, but as stringly-keyed values in a hash
+  #   @option hash [Integer] "baud" The baud. Optional
+  #   @option hash [Integer] "data_bits" The number of data bits. Optional
+  #   @option hash [Integer] "stop" The number of stop bits. Optional
+  #   @option hash [Symbol] "parity" The parity. Optional
   # @overload open(device, baud=nil, data_bits=nil, stop_bits=nil, parity=nil)
   #   Creates a new {SerialPort} and pass it to the provided block, closing automatically.
   #   @return [Object] What the block returns
@@ -152,6 +160,10 @@ class SerialPort < IO
   #   @return [Object] What the block returns
   #   @yieldparam io [SerialPort] An opened serial port
   #   @param [Hash<String, Object>] hash The given parameters, but as stringly-keyed values in a hash
+  #   @option hash [Integer] "baud" The baud. Optional
+  #   @option hash [Integer] "data_bits" The number of data bits. Optional
+  #   @option hash [Integer] "stop" The number of stop bits. Optional
+  #   @option hash [Symbol] "parity" The parity. Optional
   def self.open(device, *params)
     arg = SerialPort.new(device, *params)
     return arg unless block_given?
@@ -256,15 +268,20 @@ class Serial < SerialIO
         clear_config: true), Serial)
   end
 
-  # @!visibility private
-  # Don't doc IO methods
+  # Returns a string up to `length` long. It is not guaranteed to return the entire
+  # length specified, and will return an empty string if no data is
+  # available. If enable_blocking=true, it is identical to standard ruby IO#read
+  # except for the fact that empty reads still return empty strings instead of nil
+  # @note nonstandard IO behavior
+  # @return String
   def read(*args)
     res = super
     res.nil? ? '' : res
   end
 
-  # @!visibility private
-  # Don't doc IO methods
+  # Returns an 8 bit byte or nil if no data is available.
+  # @note nonstandard IO signature and behavior
+  # @yieldparam line [String]
   def gets(sep=$/, limit=nil)
     if block_given?
       loop do

--- a/lib/rubyserial.rb
+++ b/lib/rubyserial.rb
@@ -10,6 +10,7 @@ module RubySerial
   end
 end
 
+# Load the appropriate RubySerial::Builder
 if RubySerial::ON_WINDOWS
   require 'rubyserial/windows_constants'
   require 'rubyserial/windows'
@@ -20,4 +21,133 @@ else
     require 'rubyserial/osx_constants'
   end
   require 'rubyserial/posix'
+end
+
+# Generic IO interface
+class SerialIO < IO
+  include RubySerial::Includes
+  def self.new(address, baud_rate=9600, data_bits=8, parity=:none, stop_bits=1, parent: SerialIO, blocking: true)
+    serial, name, fd = RubySerial::Builder.build(parent: parent, address: address, baud: baud_rate, data_bits: data_bits, parity: parity, stop_bits: stop_bits, blocking: blocking)
+    serial.send :name=, name
+    serial.send :fd=, fd
+    serial
+  end
+
+  # TODO: reconfigure, etc
+
+  def inspect
+    "#<#{self.class.name}:#{name}>"
+  end
+
+  attr_reader :name
+
+  private
+  attr_writer :name, :fd
+  attr_reader :fd
+end
+
+# serial-port-style interface
+class SerialPort < IO
+  include RubySerial::Includes
+  def self.new(device, *params)
+    raise "NNNNNNN" if device.is_a? Integer
+    listargs = *params
+    listargs = listargs["baud"], listargs["data_bits"], listargs["stop_bits"], listargs["parity"] if listargs.is_a? Hash
+    baud, data, stop, par = *listargs
+
+    args = {parent: SerialPort,
+      address: device,
+      baud: baud,
+      blocking: true}
+
+    # use defaults, not nil
+    args[:data_bits] = data if data
+    args[:parity] = par if par
+    args[:stop_bits] = stop if stop
+
+    serial, name, fd = RubySerial::Builder.build(**args)
+    serial.send :name=, name
+    serial.send :fd=, fd
+    serial
+  end
+
+  def self.open(*args)
+    arg = SerialPort.new(*args)
+    begin
+      yield arg
+    ensure
+      arg.close
+    end
+  end
+  NONE = :none
+  SPACE = :space
+  MARK = :mark
+  EVEN = :even
+  ODD = :odd
+
+  def hupcl= value
+    value = !!value
+    reconfigure(false, hupcl: value)
+    value
+  end
+
+  def baud= value
+    reconfigure(false, baud: value)
+  end
+  def data_bits= value
+    reconfigure(false, data_bits: value)
+  end
+  def parity= value
+    reconfigure(false, parity: value)
+  end
+  def stop_bits= value
+    reconfigure(false, stop_bits: value)
+  end
+
+  def reconfigzure(**kwargs)
+    RubySerial::Builder.reconfigure(@fd, false, **kwargs)
+    kwargs.to_a[0][1]
+  end
+
+  private
+  attr_writer :name, :fd
+
+end
+
+# rubyserial-style interface
+class Serial < SerialIO
+  def self.new(address, baud_rate=9600, data_bits=8, parity=:none, stop_bits=1)
+    super(address, baud_rate, data_bits, parity, stop_bits, parent: Serial, blocking: false)
+  end
+
+  def read(*args)
+    res = super
+    res.nil? ? '' : res
+  end
+
+  def gets(sep=$/, limit=nil)
+    if block_given?
+      loop do
+        yield(get_until_sep(sep, limit))
+      end
+    else
+      get_until_sep(sep, limit)
+    end
+  end
+
+  private
+
+  def get_until_sep(sep, limit)
+    sep = "\n\n" if sep == ''
+    # This allows the method signature to be (sep) or (limit)
+    (limit = sep; sep="\n") if sep.is_a? Integer
+    bytes = []
+    loop do
+      current_byte = getbyte
+      bytes << current_byte unless current_byte.nil?
+      break if (bytes.last(sep.bytes.to_a.size) == sep.bytes.to_a) || ((bytes.size == limit) if limit)
+    end
+
+    bytes.map { |e| e.chr }.join
+  end
 end

--- a/lib/rubyserial/configuration.rb
+++ b/lib/rubyserial/configuration.rb
@@ -1,0 +1,23 @@
+# Copyright (c) 2019 Patrick Plenefisch
+
+
+module RubySerial
+  # TODO: flow_control , :read_timeout, :write_timeout)
+  
+  # Configuration Struct passed to create a serial port, or returned back from a reconfiguration. Shows all current configurations.
+  # When passed as a request, nil means no update, any other value is a request to update.
+  # @example
+  #   cfg = Configuration.new
+  #   cfg.baud = 9600
+  #   cfg[:device] = "COM1"
+  #   cfg[:baud] #=> 9600
+  Configuration = Struct.new(:device, :baud, :data_bits, :parity, :stop_bits, :hupcl, :enable_blocking, :clear_config)
+  class Configuration
+  	# Builds a Configuration object using the given keyword arguments
+  	# @example
+  	#   Configuration.from(baud: 9600) #=>  #<struct RubySerial::Configuration device=nil, baud=9600, data_bits=nil, parity=nil, stop_bits=nil, hupcl=nil, enable_blocking=nil, clear_config=nil>
+    def self.from(**kwargs)
+      kwargs.each_with_object(new) {|(arg, val),o| o[arg] = val}
+    end
+  end
+end

--- a/lib/rubyserial/linux_constants.rb
+++ b/lib/rubyserial/linux_constants.rb
@@ -4,6 +4,9 @@
 module RubySerial
   # @api private
   # @!visibility private
+  ENOTTY_MAP="ENOTTY"
+  # @api private
+  # @!visibility private
   module Posix
     extend FFI::Library
     ffi_lib FFI::Library::LIBC
@@ -32,6 +35,7 @@ module RubySerial
     CSIZE = 0000060
     CBAUD = 0010017
     HUPCL = 0002000
+    HUPCL_HACK=false
 
     DATA_BITS = {
       5 => 0000000,
@@ -84,6 +88,7 @@ module RubySerial
       1 => 0x00000000,
       2 => CSTOPB
     }
+
 
     ERROR_CODES = {
       1 => "EPERM",

--- a/lib/rubyserial/linux_constants.rb
+++ b/lib/rubyserial/linux_constants.rb
@@ -1,8 +1,11 @@
 # Copyright (c) 2014-2016 The Hybrid Group
+# Copyright (c) 2019 Patrick Plenefisch
 
 module RubySerial
+  # @api private
+  # @!visibility private
   module Posix
-  extend FFI::Library
+    extend FFI::Library
     ffi_lib FFI::Library::LIBC
 
     O_NONBLOCK = 00004000

--- a/lib/rubyserial/linux_constants.rb
+++ b/lib/rubyserial/linux_constants.rb
@@ -16,11 +16,19 @@ module RubySerial
     IGNPAR = 0000004
     PARENB = 0000400
     PARODD = 0001000
+    PARITY_FIELD = PARENB | PARODD
     CSTOPB = 0000100
     CREAD  = 0000200
     CLOCAL = 0004000
     VMIN = 6
     NCCS = 32
+    IXON = 0002000
+    IXANY = 0004000
+    IXOFF = 0010000
+    CRTSCTS = 020000000000
+    CSIZE = 0000060
+    CBAUD = 0010017
+    HUPCL = 0002000
 
     DATA_BITS = {
       5 => 0000000,
@@ -29,7 +37,7 @@ module RubySerial
       8 => 0000060
     }
 
-    BAUDE_RATES = {
+    BAUD_RATES = {
       0 => 0000000,
       50 => 0000001,
       75 => 0000002,
@@ -217,12 +225,8 @@ module RubySerial
               :c_ospeed, :uint
     end
 
-    attach_function :ioctl, [ :int, :ulong, RubySerial::Posix::Termios], :int, blocking: true
     attach_function :tcsetattr, [ :int, :int, RubySerial::Posix::Termios ], :int, blocking: true
+    attach_function :tcgetattr, [ :int, RubySerial::Posix::Termios ], :int, blocking: true
     attach_function :fcntl, [:int, :int, :varargs], :int, blocking: true
-    attach_function :open, [:pointer, :int], :int, blocking: true
-    attach_function :close, [:int], :int, blocking: true
-    attach_function :write, [:int, :pointer,  :int],:int, blocking: true
-    attach_function :read, [:int, :pointer,  :int],:int, blocking: true
   end
 end

--- a/lib/rubyserial/osx_constants.rb
+++ b/lib/rubyserial/osx_constants.rb
@@ -13,14 +13,22 @@ module RubySerial
     IGNPAR = 0x00000004
     PARENB = 0x00001000
     PARODD = 0x00002000
+    PARITY_FIELD = PARENB | PARODD
     VMIN = 16
     VTIME = 17
     CLOCAL = 0x00008000
     CSTOPB = 0x00000400
     CREAD  = 0x00000800
     CCTS_OFLOW = 0x00010000 # Clearing this disables RTS AND CTS.
+    CRTS_IFLOW = 0x00020000
     TCSANOW = 0
     NCCS = 20
+    IXON = 0x00000200
+    IXOFF = 0x00000400
+    IXANY = 0x00000800
+    CRTSCTS = CCTS_OFLOW | CRTS_IFLOW
+    CSIZE = 0x00000300
+    HUPCL = 0x00004000
 
     DATA_BITS = {
       5 => 0x00000000,
@@ -29,7 +37,7 @@ module RubySerial
       8 => 0x00000300
     }
 
-    BAUDE_RATES = {
+    BAUD_RATES = {
       0 => 0,
       50 => 50,
       75 => 75,
@@ -187,10 +195,7 @@ module RubySerial
     end
 
     attach_function :tcsetattr, [ :int, :int, RubySerial::Posix::Termios ], :int, blocking: true
+    attach_function :tcgetattr, [ :int, RubySerial::Posix::Termios ], :int, blocking: true
     attach_function :fcntl, [:int, :int, :varargs], :int, blocking: true
-    attach_function :open, [:pointer, :int], :int, blocking: true
-    attach_function :close, [:int], :int, blocking: true
-    attach_function :write, [:int, :pointer,  :int],:int, blocking: true
-    attach_function :read, [:int, :pointer,  :int],:int, blocking: true
   end
 end

--- a/lib/rubyserial/osx_constants.rb
+++ b/lib/rubyserial/osx_constants.rb
@@ -5,6 +5,9 @@
 module RubySerial
   # @api private
   # @!visibility private
+  ENOTTY_MAP="ENODEV"
+  # @api private
+  # @!visibility private
   module Posix
   extend FFI::Library
     ffi_lib FFI::Library::LIBC
@@ -33,6 +36,7 @@ module RubySerial
     CRTSCTS = CCTS_OFLOW | CRTS_IFLOW
     CSIZE = 0x00000300
     HUPCL = 0x00004000
+    HUPCL_HACK=true
 
     DATA_BITS = {
       5 => 0x00000000,

--- a/lib/rubyserial/osx_constants.rb
+++ b/lib/rubyserial/osx_constants.rb
@@ -1,6 +1,10 @@
 # Copyright (c) 2014-2016 The Hybrid Group
+# Copyright (c) 2019 Patrick Plenefisch
+
 
 module RubySerial
+  # @api private
+  # @!visibility private
   module Posix
   extend FFI::Library
     ffi_lib FFI::Library::LIBC

--- a/lib/rubyserial/posix.rb
+++ b/lib/rubyserial/posix.rb
@@ -1,46 +1,67 @@
 # Copyright (c) 2014-2016 The Hybrid Group
+# Copyright (c) 2019 Patrick Plenefisch
 
+
+##
+# Low-level API. May change between minor releases. For stability, see {Serial} or {SerialPort}.
 class RubySerial::Builder
-  def self.build(address: , parent: IO, baud: 9600, data_bits: 8, parity: :none, stop_bits: 1, blocking: true, clear_config: true)
-    fd = IO::sysopen(address, File::RDWR | File::NOCTTY | File::NONBLOCK)
+  ##
+  # Creates an instance of the given parent class to be a serial port with the given configuration
+  #
+  # @example
+  #   RubySerial::Builder.build(SerialIO, RubySerial::Configuration.from(device: "/dev/ttyS0"))
+  #     #=> [#<SerialIO:/dev/ttyS0>, 3, #<struct RubySerial::Configuration device="/dev/ttyS0", baud=9600, data_bits=8, parity=:none, stop_bits=1, hupcl=false, enable_blocking=nil, clear_config=nil>]
+  #
+  # @param [Class] parent A class that is_a? IO and has included the {RubySerial::Includes} module
+  # @param [RubySerial::Configuration] config The details of the serial port to open
+  # @return [parent, Integer, RubySerial::Configuration] A new instance of parent, the file descriptor, and the current configuration of the serial port
+  # @raise [Errno::ENOENT] If not a valid file
+  # @raise [RubySerial::Error] If not a TTY device (only on non-windows platforms), or any other general error
+  def self.build(parent, config)
+    fd = IO::sysopen(config.device, File::RDWR | File::NOCTTY | File::NONBLOCK)
 
-    # enable blocking mode
-    if blocking
-    fl = ffi_call(:fcntl, fd, RubySerial::Posix::F_GETFL, :int, 0)
-    ffi_call(:fcntl, fd, RubySerial::Posix::F_SETFL, :int, ~RubySerial::Posix::O_NONBLOCK & fl)
+    # enable blocking mode. I'm not sure why we do it this way, with disable and then re-enable. History suggests that it might be a mac thing
+    if config.enable_blocking
+      fl = ffi_call(:fcntl, fd, RubySerial::Posix::F_GETFL, :int, 0)
+      ffi_call(:fcntl, fd, RubySerial::Posix::F_SETFL, :int, ~RubySerial::Posix::O_NONBLOCK & fl)
     end
 
     # Update the terminal settings
-    reconfigure(fd, clear_config, min: (blocking ? 1 : 0), baud: baud, data_bits: data_bits, parity: parity, stop_bits: stop_bits)
+    out_config = reconfigure(fd, config)
+    out_config.device = config.device
 
     file = parent.send(:for_fd, fd, File::RDWR | File::SYNC)
-    file._posix_fd = fd
-    unless file.tty?
-      raise ArgumentError, "not a serial port: #{address}"
-    end
-    [file, address, fd]
+    file.send :_rs_posix_init, fd
+
+    return [file, fd, out_config]
   end
 
-  def self.reconfigure(fd, clear_config, hupcl: nil, baud: nil, data_bits: nil, parity: nil, stop_bits: nil, min: nil)
+  # @api private
+  # @!visibility private
+  # Reconfigures the given (platform-specific) file handle with the provided configuration. See {RubySerial::Includes#reconfigure} for public API
+  def self.reconfigure(fd, req_config)
     # Update the terminal settings
     config = RubySerial::Posix::Termios.new
     ffi_call(:tcgetattr, fd, config)
-    edit_config(config, clear_config, baud_rate: baud, data_bits: data_bits, parity: parity, stop_bits: stop_bits, hupcl: hupcl, min: min)
+    out_config = edit_config(config, req_config, min: {nil => nil, true => 1, false => 0}[req_config.enable_blocking])
     ffi_call(:tcsetattr, fd, RubySerial::Posix::TCSANOW, config)
+    out_config
   end
 
   private
 
+  # Calls the given FFI target, and raises an error if it fails
   def self.ffi_call target, *args
-  res = RubySerial::Posix.send(target, *args)
+    res = RubySerial::Posix.send(target, *args)
     if res == -1
       raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
     end
     res
   end
 
+  # Sets the given config value (if provided), and returns the current value
   def self.set config, field, flag, value, map = nil
-    return if value.nil?
+    return get((config[field] & flag), map) if value.nil?
     trueval = if map.nil?
       if !!value == value # boolean values set to the flag
         value ? flag : 0
@@ -53,10 +74,19 @@ class RubySerial::Builder
     raise RubySerial::Error, "Values out of range: #{value}" unless trueval.is_a? Integer
     # mask the whole field, and set new value
     config[field] = (config[field] & ~flag) | trueval
+    value
   end
 
-  def self.edit_config(config, clear, min: nil, baud_rate: nil, data_bits: nil, parity: nil, stop_bits: nil, hupcl: nil)
-    if clear
+  def self.get value, options
+    return value != 0 if options.nil?
+    options.key(value)
+  end
+
+  # Updates the configuration object with the requested configuration
+  def self.edit_config(config, req, min: nil)
+    actual = RubySerial::Configuration.from(clear_config: req.clear_config)
+
+    if req.clear_config
       # reset everything except for flow settings
       config[:c_iflag] &= (RubySerial::Posix::IXON | RubySerial::Posix::IXOFF | RubySerial::Posix::IXANY | RubySerial::Posix::CRTSCTS)
       config[:c_iflag] |= RubySerial::Posix::IGNPAR
@@ -67,31 +97,36 @@ class RubySerial::Builder
 
     config[:cc_c][RubySerial::Posix::VMIN] = min unless min.nil?
 
-    unless baud_rate.nil?
+    unless req.baud.nil?
       # Masking in baud rate on OS X would corrupt the settings.
       if RubySerial::ON_LINUX
-        set config, :c_cflag, RubySerial::Posix::CBAUD, baud_rate, RubySerial::Posix::BAUD_RATES
+        set config, :c_cflag, RubySerial::Posix::CBAUD, req.baud, RubySerial::Posix::BAUD_RATES
       end
 
-      config[:c_ospeed] = config[:c_ispeed] = RubySerial::Posix::BAUD_RATES[baud_rate]
+      config[:c_ospeed] = config[:c_ispeed] = RubySerial::Posix::BAUD_RATES[req.baud]
     end
+    actual.baud = get config[:c_ispeed], RubySerial::Posix::BAUD_RATES
 
-    set config, :c_cflag, RubySerial::Posix::CSIZE, data_bits, RubySerial::Posix::DATA_BITS
-    set config, :c_cflag, RubySerial::Posix::PARITY_FIELD, parity, RubySerial::Posix::PARITY
-    set config, :c_cflag, RubySerial::Posix::CSTOPB, stop_bits, RubySerial::Posix::STOPBITS
-    set config, :c_cflag, RubySerial::Posix::HUPCL, hupcl
+    actual.data_bits = set config, :c_cflag, RubySerial::Posix::CSIZE, req.data_bits, RubySerial::Posix::DATA_BITS
+    actual.parity = set config, :c_cflag, RubySerial::Posix::PARITY_FIELD, req.parity, RubySerial::Posix::PARITY
+    actual.stop_bits = set config, :c_cflag, RubySerial::Posix::CSTOPB, req.stop_bits, RubySerial::Posix::STOPBITS
+    actual.hupcl = set config, :c_cflag, RubySerial::Posix::HUPCL, req.hupcl
 
-    config
+    return actual
   end
 end
 
-# Module that must be included in the parent class for RubySerial::Builder to work correctly
+# The module that must be included in the parent class (such as {SerialIO}, {Serial}, or {SerialPort}) for {RubySerial::Builder} to work correctly. These methods are thus on all RubySerial objects.
 module RubySerial::Includes
-  def reconfigure(clear_config, hupcl: nil, baud: nil, data_bits: nil, parity: nil, stop_bits: nil, min: nil)
-    RubySerial::Builder.reconfigure(@_rs_fd, clear_config, hupcl: hupcl, baud: baud, data_bits: data_bits, parity: parity, stop_bits: stop_bits, min: min)
+  # Reconfigures the serial port with the given new values, if provided. Pass nil to keep the current settings.
+  # @return [RubySerial::Configuration) The currently configured values for this serial port.
+  def reconfigure(hupcl: nil, baud: nil, data_bits: nil, parity: nil, stop_bits: nil)
+    RubySerial::Builder.reconfigure(@_rs_posix_fd, RubySerial::Configuration.from(hupcl: hupcl, baud: baud, data_bits: data_bits, parity: parity, stop_bits: stop_bits))
   end
 
-  def _posix_fd= fd
-    @_rs_fd = fd
+  # TODO: dts set on linux?
+  private
+  def _rs_posix_init(fd)
+    @_rs_posix_fd = fd
   end
 end

--- a/lib/rubyserial/posix.rb
+++ b/lib/rubyserial/posix.rb
@@ -1,132 +1,97 @@
 # Copyright (c) 2014-2016 The Hybrid Group
 
-class Serial
-  def initialize(address, baude_rate=9600, data_bits=8, parity=:none, stop_bits=1)
-    file_opts = RubySerial::Posix::O_RDWR | RubySerial::Posix::O_NOCTTY | RubySerial::Posix::O_NONBLOCK
-    @fd = RubySerial::Posix.open(address, file_opts)
+class RubySerial::Builder
+  def self.build(address: , parent: IO, baud: 9600, data_bits: 8, parity: :none, stop_bits: 1, blocking: true, clear_config: true)
+    fd = IO::sysopen(address, File::RDWR | File::NOCTTY | File::NONBLOCK)
 
-    if @fd == -1
-      raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
-    else
-      @open = true
+    # enable blocking mode
+    if blocking
+    fl = ffi_call(:fcntl, fd, RubySerial::Posix::F_GETFL, :int, 0)
+    ffi_call(:fcntl, fd, RubySerial::Posix::F_SETFL, :int, ~RubySerial::Posix::O_NONBLOCK & fl)
     end
 
-    fl = RubySerial::Posix.fcntl(@fd, RubySerial::Posix::F_GETFL, :int, 0)
-    if fl == -1
-      raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
-    end
+    # Update the terminal settings
+    reconfigure(fd, clear_config, min: (blocking ? 1 : 0), baud: baud, data_bits: data_bits, parity: parity, stop_bits: stop_bits)
 
-    err = RubySerial::Posix.fcntl(@fd, RubySerial::Posix::F_SETFL, :int, ~RubySerial::Posix::O_NONBLOCK & fl)
-    if err == -1
-      raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
+    file = parent.send(:for_fd, fd, File::RDWR | File::SYNC)
+    file._posix_fd = fd
+    unless file.tty?
+      raise ArgumentError, "not a serial port: #{address}"
     end
-
-    @config = build_config(baude_rate, data_bits, parity, stop_bits)
-
-    err = RubySerial::Posix.tcsetattr(@fd, RubySerial::Posix::TCSANOW, @config)
-    if err == -1
-      raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
-    end
+    [file, address, fd]
   end
 
-  def closed?
-    !@open
-  end
-
-  def close
-    err = RubySerial::Posix.close(@fd)
-    if err == -1
-      raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
-    else
-      @open = false
-    end
-  end
-
-  def write(data)
-    data = data.to_s
-    n =  0
-    while data.size > n do
-      buff = FFI::MemoryPointer.from_string(data[n..-1].to_s)
-      i = RubySerial::Posix.write(@fd, buff, buff.size-1)
-      if i == -1
-        raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
-      else
-        n = n+i
-      end
-    end
-
-    # return number of bytes written
-    n
-  end
-
-  def read(size)
-    buff = FFI::MemoryPointer.new :char, size
-    i = RubySerial::Posix.read(@fd, buff, size)
-    if i == -1
-      raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
-    end
-    buff.get_bytes(0, i)
-  end
-
-  def getbyte
-    buff = FFI::MemoryPointer.new :char, 1
-    i = RubySerial::Posix.read(@fd, buff, 1)
-    if i == -1
-      raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
-    end
-
-    if i == 0
-      nil
-    else
-      buff.get_bytes(0,1).bytes.first
-    end
-  end
-
-  def gets(sep=$/, limit=nil)
-    if block_given?
-      loop do
-        yield(get_until_sep(sep, limit))
-      end
-    else
-      get_until_sep(sep, limit)
-    end
+  def self.reconfigure(fd, clear_config, hupcl: nil, baud: nil, data_bits: nil, parity: nil, stop_bits: nil, min: nil)
+    # Update the terminal settings
+    config = RubySerial::Posix::Termios.new
+    ffi_call(:tcgetattr, fd, config)
+    edit_config(config, clear_config, baud_rate: baud, data_bits: data_bits, parity: parity, stop_bits: stop_bits, hupcl: hupcl, min: min)
+    ffi_call(:tcsetattr, fd, RubySerial::Posix::TCSANOW, config)
   end
 
   private
 
-  def get_until_sep(sep, limit)
-    sep = "\n\n" if sep == ''
-    # This allows the method signature to be (sep) or (limit)
-    (limit = sep; sep="\n") if sep.is_a? Integer
-    bytes = []
-    loop do
-      current_byte = getbyte
-      bytes << current_byte unless current_byte.nil?
-      break if (bytes.last(sep.bytes.to_a.size) == sep.bytes.to_a) || ((bytes.size == limit) if limit)
+  def self.ffi_call target, *args
+  res = RubySerial::Posix.send(target, *args)
+    if res == -1
+      raise RubySerial::Error, RubySerial::Posix::ERROR_CODES[FFI.errno]
     end
-
-    bytes.map { |e| e.chr }.join
+    res
   end
 
-  def build_config(baude_rate, data_bits, parity, stop_bits)
-    config = RubySerial::Posix::Termios.new
+  def self.set config, field, flag, value, map = nil
+    return if value.nil?
+    trueval = if map.nil?
+      if !!value == value # boolean values set to the flag
+        value ? flag : 0
+      else
+        value
+      end
+    else
+      map[value]
+    end
+    raise RubySerial::Error, "Values out of range: #{value}" unless trueval.is_a? Integer
+    # mask the whole field, and set new value
+    config[field] = (config[field] & ~flag) | trueval
+  end
 
-    config[:c_iflag]  = RubySerial::Posix::IGNPAR
-    config[:c_ispeed] = RubySerial::Posix::BAUDE_RATES[baude_rate]
-    config[:c_ospeed] = RubySerial::Posix::BAUDE_RATES[baude_rate]
-    config[:c_cflag]  = RubySerial::Posix::DATA_BITS[data_bits] |
-      RubySerial::Posix::CREAD |
-      RubySerial::Posix::CLOCAL |
-      RubySerial::Posix::PARITY[parity] |
-      RubySerial::Posix::STOPBITS[stop_bits]
-
-    # Masking in baud rate on OS X would corrupt the settings.
-    if RubySerial::ON_LINUX
-      config[:c_cflag] = config[:c_cflag] | RubySerial::Posix::BAUDE_RATES[baude_rate]
+  def self.edit_config(config, clear, min: nil, baud_rate: nil, data_bits: nil, parity: nil, stop_bits: nil, hupcl: nil)
+    if clear
+      # reset everything except for flow settings
+      config[:c_iflag] &= (RubySerial::Posix::IXON | RubySerial::Posix::IXOFF | RubySerial::Posix::IXANY | RubySerial::Posix::CRTSCTS)
+      config[:c_iflag] |= RubySerial::Posix::IGNPAR
+      config[:c_oflag] = 0
+      config[:c_cflag] = RubySerial::Posix::CREAD | RubySerial::Posix::CLOCAL
+      config[:c_lflag] = 0
     end
 
-    config[:cc_c][RubySerial::Posix::VMIN] = 0
+    config[:cc_c][RubySerial::Posix::VMIN] = min unless min.nil?
+
+    unless baud_rate.nil?
+      # Masking in baud rate on OS X would corrupt the settings.
+      if RubySerial::ON_LINUX
+        set config, :c_cflag, RubySerial::Posix::CBAUD, baud_rate, RubySerial::Posix::BAUD_RATES
+      end
+
+      config[:c_ospeed] = config[:c_ispeed] = RubySerial::Posix::BAUD_RATES[baud_rate]
+    end
+
+    set config, :c_cflag, RubySerial::Posix::CSIZE, data_bits, RubySerial::Posix::DATA_BITS
+    set config, :c_cflag, RubySerial::Posix::PARITY_FIELD, parity, RubySerial::Posix::PARITY
+    set config, :c_cflag, RubySerial::Posix::CSTOPB, stop_bits, RubySerial::Posix::STOPBITS
+    set config, :c_cflag, RubySerial::Posix::HUPCL, hupcl
 
     config
+  end
+end
+
+# Module that must be included in the parent class for RubySerial::Builder to work correctly
+module RubySerial::Includes
+  def reconfigure(clear_config, hupcl: nil, baud: nil, data_bits: nil, parity: nil, stop_bits: nil, min: nil)
+    RubySerial::Builder.reconfigure(@_rs_fd, clear_config, hupcl: hupcl, baud: baud, data_bits: data_bits, parity: parity, stop_bits: stop_bits, min: min)
+  end
+
+  def _posix_fd= fd
+    @_rs_fd = fd
   end
 end

--- a/lib/rubyserial/version.rb
+++ b/lib/rubyserial/version.rb
@@ -1,7 +1,9 @@
 # Copyright (c) 2014-2018 The Hybrid Group and Friends
 
+
 module RubySerial
   unless const_defined?('VERSION')
+    # Version of RubySerial
     VERSION = "1.0.0"
   end
 end

--- a/lib/rubyserial/version.rb
+++ b/lib/rubyserial/version.rb
@@ -2,6 +2,6 @@
 
 module RubySerial
   unless const_defined?('VERSION')
-    VERSION = "0.6.0"
+    VERSION = "1.0.0"
   end
 end

--- a/lib/rubyserial/windows.rb
+++ b/lib/rubyserial/windows.rb
@@ -1,114 +1,59 @@
 # Copyright (c) 2014-2016 The Hybrid Group
+# Copyright (c) 2019 Patrick Plenefisch
+
 
 class RubySerial::Builder
-  def self.build(address: , parent: IO, baud: 9600, data_bits: 8, parity: :none, stop_bits: 1, blocking: true, clear_config: true, winfix: :auto) # TODO: blocking & clear_config
+  def self.build(parent, config)
     fd = IO::sysopen("\\\\.\\#{address}", File::RDWR)
-
-    # enable blocking mode TODO
 
     hndl = RubySerial::WinC._get_osfhandle(fd)
     # TODO: check errno
 
-    winfix_out = [] # TODO: remove winfix
     # Update the terminal settings
-    _reconfigure(winfix_out, hndl, clear_config, baud: baud, data_bits: data_bits, parity: parity, stop_bits: stop_bits) # TODO: min: (blocking ? 1 : 0),
+    out_config = reconfigure(hndl, config) # TODO: clear_config
+    out_config.device = config.device
 
-    ffi_call :SetupComm, hndl, 64, 64
+    ffi_call :SetupComm, hndl, 64, 64 # Set the buffers to 64 bytes
 
-    win32_update_readmode :blocking, hndl
+    blocking_mode = config.enable_blocking ? :blocking : :nonblocking
+    win32_update_readmode(blocking_mode, hndl)
 
     file = parent.send(:for_fd, fd, File::RDWR)
-    # windows has no idea
-    #unless file.tty?
-    #  raise ArgumentError, "not a serial port: #{address}"
-    #end
-    file._win32_hndl = hndl
-    file._winfix = winfix
-    #file.dtr = false
-    [file, address, fd]
+    file.send :_rs_win32_init, hndl, blocking_mode
+
+    return [file, fd, out_config]
   end
 
-  WIN32_READMODES = {
-    :blocking => [0, 0, 0],
-    :partial => [2, 0, 0],
-    :nonblocking => [0xffff_ffff, 0, 0]
-  }
-
-  def self.win32_update_readmode(mode, hwnd)
-    t = RubySerial::Win32::CommTimeouts.new
-    ffi_call :GetCommTimeouts, hwnd, t
-    raise "ack TODO" if WIN32_READMODES[mode].nil?
-    t[:read_interval_timeout], t[:read_total_timeout_multiplier], t[:read_total_timeout_constant] = *WIN32_READMODES[mode]
-      # do we need to set these?
-      #timeouts[:write_total_timeout_multiplier] #= 1
-      #timeouts[:write_total_timeout_constant]   #= 10
-  #    puts "comT: #{w32_pct t}"
-   ffi_call :SetCommTimeouts, hwnd, t
-  end
-
-
-
-  def self._reconfigure(io, hndl, clear_config, hupcl: nil, baud: nil, data_bits: nil, parity: nil, stop_bits: nil, min: nil)
-
-
+  # @api private
+  # @!visibility private
+  # Reconfigures the given (platform-specific) file handle with the provided configuration. See {RubySerial::Includes#reconfigure} for public API
+  def self.reconfigure(hndl, req_config)
     # Update the terminal settings
     dcb = RubySerial::Win32::DCB.new
     dcb[:dcblength] = RubySerial::Win32::DCB::Sizeof
     ffi_call :GetCommState, hndl, dcb
-      dcb[:baudrate] = baud if baud
-      dcb[:bytesize] = data_bits if data_bits
-      dcb[:stopbits] = RubySerial::Win32::DCB::STOPBITS[stop_bits] if stop_bits
-      dcb[:parity]   = RubySerial::Win32::DCB::PARITY[parity] if parity
-
-      dcb[:flags] &= ~(0x3000) # clear
-      #doreset =
-      unless hupcl.nil?
-      cfl = (dcb[:flags] & 48) / 16
-      dtr = hupcl
-      rts = hupcl ? 0 : 0
- #     p cfl
-      dcb[:flags] &= ~(48 + 0x3000) # clear
-      dcb[:flags] |= 16 if dtr # set
-      dcb[:flags] |= 0x1000*rts  # set
-      if cfl > 0 && !dtr
-        # TODO: ???
-      end
-      end
-#    dcb[:flags] &= ~48
-# DTR control
-  #p dcb[:flags] # 4225, binary, txcontinuexonxoff, rtscontrol=1
-  #p w32_dab(dcb)
-  #4241 = 4225 +fDtrControl=1
-   ffi_call :SetCommState, hndl, dcb
-
+    out_config = edit_config(dcb, req_config)
+    ffi_call :SetCommState, hndl, dcb
+    out_config
   end
 
-  def self.w32_dab(t)
-  [ :dcblength,
-              :baudrate,
-              :flags,
-              :wreserved,
-              :xonlim,
-              :xofflim,
-              :bytesize,
-              :parity,
-              :stopbits,
-              :xonchar,
-              :xoffchar,
-              :errorchar,
-              :eofchar,
-              :evtchar,
-              :wreserved1].map{|x|t[x]}
+  private
+
+  # Changes the read mode timeouts to accomidate the desired blocking mode
+  def self.win32_update_readmode(mode, hwnd)
+    t = RubySerial::Win32::CommTimeouts.new
+
+    ffi_call :GetCommTimeouts, hwnd, t
+    raise ArgumentError, "Invalid mode: #{mode}" if RubySerial::Win32::CommTimeouts::READ_MODES[mode].nil?
+
+    # Leave the write alone, just set the read timeouts
+    t[:read_interval_timeout], t[:read_total_timeout_multiplier], t[:read_total_timeout_constant] = *RubySerial::Win32::CommTimeouts::READ_MODES[mode]
+
+    #puts "com details: #{t.dbg_a}"
+    ffi_call :SetCommTimeouts, hwnd, t
   end
 
-  def self.w32_pct(t)
-    [:read_interval_timeout,
-              :read_total_timeout_multiplier,
-              :read_total_timeout_constant,
-              :write_total_timeout_multiplier,
-              :write_total_timeout_constant].map{|f| t[f]}
-  end
-
+  # Calls the given FFI target, and raises an error if it fails
   def self.ffi_call who, *args
      res = RubySerial::Win32.send who, *args
      if res == 0
@@ -117,16 +62,48 @@ class RubySerial::Builder
    res
   end
 
+  # Updates the configuration object with the requested configuration
+  def self.edit_config(dcb, req)
+    actual = RubySerial::Configuration.new
+
+    dcb[:baudrate] = req.baud if req.baud
+    dcb[:bytesize] = req.data_bits if req.data_bits
+    dcb[:stopbits] = RubySerial::Win32::DCB::STOPBITS[req.stop_bits] if req.stop_bits
+    dcb[:parity]   = RubySerial::Win32::DCB::PARITY[req.parity] if req.parity
+
+    dcb[:flags]  &= ~RubySerial::Win32::DCB::FLAGS_RTS # Always clear the RTS bit
+    unless req.hupcl.nil?
+      dcb[:flags] &= ~RubySerial::Win32::DCB::DTR_MASK
+      dcb[:flags] |= ~RubySerial::Win32::DCB::DTR_ENABLED if req.hupcl
+    end
+
+    actual.baud = dcb[:baudrate]
+    actual.data_bits = dcb[:bytesize]
+    actual.stop_bits = RubySerial::Win32::DCB::STOPBITS.key(dcb[:stopbits])
+    actual.parity = RubySerial::Win32::DCB::PARITY.key(dcb[:parity])
+    actual.hupcl = (dcb[:flags] & RubySerial::Win32::DCB::DTR_MASK) != 0
+
+    return actual
+  end
 end
-# Copyright (c) 2014-2016 The Hybrid Group
 
 module RubySerial::Includes
+  def reconfigure(hupcl: nil, baud: nil, data_bits: nil, parity: nil, stop_bits: nil)
+    RubySerial::Builder.reconfigure(self, @_rs_win32_hndl, RubySerial::Configuration.from(hupcl: hupcl, baud: baud, data_bits: data_bits, parity: parity, stop_bits: stop_bits))
+  end
+
+  # Ruby IO has issues with nonblocking from_fd on windows, so override just to change the underlying timeouts
+  # @api private
+  # @!visibility private
   def readpartial(*args, _bypass: false)
     change_win32_mode :partial unless _bypass
     super(*args)
   end
 
-  def read_nonblock(maxlen, buf=nil, exception: true)
+  # Ruby IO has issues with nonblocking from_fd on windows, so override just to change the underlying timeouts
+  # @api private
+  # @!visibility private
+  def read_nonblock(maxlen, buf=nil, exception: true) # TODO: support exception
     change_win32_mode :nonblocking
     if buf.nil?
       readpartial(maxlen, _bypass: true)
@@ -137,42 +114,46 @@ module RubySerial::Includes
     raise IO::EAGAINWaitReadable, "Resource temporarily unavailable - read would block"
   end
 
+  # Ruby IO has issues with nonblocking from_fd on windows, so override just to change the underlying timeouts
   [:read, :pread, :readbyte, :readchar, :readline, :readlines, :sysread, :getbyte, :getc, :gets].each do |name|
     define_method name do |*args|
-      change_win32_mode :blocking
+      change_win32_mode @_rs_win32_blocking
       super(*args)
     end
   end
 
+  # Ruby IO has issuew with nonblocking from_fd on windows, so override just to change the underlying timeouts
+  # @api private
+  # @!visibility private
   def write_nonblock(*args)
-    # TODO: support write_nonblock on windows
+    # TODO: properly support write_nonblock on windows
     write(*args)
   end
 
+  private
+
+  ##
+  # Updates the timeouts (if applicable) to emulate the requested read type
   def change_win32_mode type
     return if @_win32_curr_read_mode == type
-    # Ugh, have to change the mode now
-    RubySerial::Builder.win32_update_readmode(type, @_rs_hwnd)
+
+    # have to change the mode now
+    RubySerial::Builder.win32_update_readmode(type, @_rs_win32_hndl)
     @_win32_curr_read_mode = type
   end
 
-  def _win32_hndl= hwnd
-    @_rs_hwnd = hwnd
-    @_win32_curr_read_mode = :blocking
+  def _rs_win32_init(hndl, blocking_mode)
+    @_rs_win32_hndl = hndl
+    @_rs_win32_blocking = blocking_mode
+    @_rs_win32_curr_read_mode = blocking_mode
   end
 
-  def reconfigure(clear_config, hupcl: nil, baud: nil, data_bits: nil, parity: nil, stop_bits: nil, min: nil)
-    RubySerial::Builder._reconfigure(self, @_rs_hwnd, clear_config, hupcl: hupcl, baud: baud, data_bits: data_bits, parity: parity, stop_bits: stop_bits, min: min)
-  end
+  # TODO: make cross platform...
+  #def dtr= val
+  #  RubySerial::Builder.ffi_call :EscapeCommFunction, @_rs_hwnd, (val ? 5 : 6)
+  #end
 
-  def dtr= val
-    RubySerial::Builder.ffi_call :EscapeCommFunction, @_rs_hwnd, (val ? 5 : 6)
-  end
-
-  def rts= val
-    RubySerial::Builder.ffi_call :EscapeCommFunction, @_rs_hwnd, (val ? 3 : 4)
-  end
-
-  def _winfix= val
-  end
+  #def rts= val
+  #  RubySerial::Builder.ffi_call :EscapeCommFunction, @_rs_hwnd, (val ? 3 : 4)
+  #end
 end

--- a/lib/rubyserial/windows.rb
+++ b/lib/rubyserial/windows.rb
@@ -64,7 +64,7 @@ class RubySerial::Builder
 
   # Updates the configuration object with the requested configuration
   def self.edit_config(dcb, req)
-    actual = RubySerial::Configuration.new
+    actual = RubySerial::Configuration.from(device: req.device)
 
     dcb[:baudrate] = req.baud if req.baud
     dcb[:bytesize] = req.data_bits if req.data_bits

--- a/lib/rubyserial/windows_constants.rb
+++ b/lib/rubyserial/windows_constants.rb
@@ -1,6 +1,10 @@
 # Copyright (c) 2014-2016 The Hybrid Group
+# Copyright (c) 2019 Patrick Plenefisch
+
 
 module RubySerial
+  # @api private
+  # @!visibility private
   module WinC
     extend FFI::Library
     ffi_lib 'msvcrt'
@@ -10,6 +14,8 @@ module RubySerial
     attach_function :_get_osfhandle,     [:int], :pointer, blocking: true
   end
 
+  # @api private
+  # @!visibility private
   module Win32
     extend FFI::Library
     ffi_lib 'kernel32'
@@ -276,6 +282,30 @@ module RubySerial
         :odd  => ODDPARITY,
         :even => EVENPARITY
       }
+
+      FLAGS_RTS = 0x3000
+
+      DTR_MASK = 48
+      DTR_ENABLED = 16
+
+      # debug function to return all values as an array
+      def dbg_a
+        [ :dcblength,
+              :baudrate,
+              :flags,
+              :wreserved,
+              :xonlim,
+              :xofflim,
+              :bytesize,
+              :parity,
+              :stopbits,
+              :xonchar,
+              :xoffchar,
+              :errorchar,
+              :eofchar,
+              :evtchar,
+              :wreserved1].map{|x|self[x]}
+      end
     end
 
     class CommTimeouts < FFI::Struct
@@ -284,6 +314,21 @@ module RubySerial
               :read_total_timeout_constant,     :uint32,
               :write_total_timeout_multiplier,  :uint32,
               :write_total_timeout_constant,    :uint32
+
+      # debug function to return all values as an array
+      def dbg_a
+        [:read_interval_timeout,
+              :read_total_timeout_multiplier,
+              :read_total_timeout_constant,
+              :write_total_timeout_multiplier,
+              :write_total_timeout_constant].map{|f| self[f]}
+      end
+
+      READ_MODES = {
+        :blocking => [0, 0, 0],
+        :partial => [2, 0, 0],
+        :nonblocking => [0xffff_ffff, 0, 0]
+      }
     end
 
     attach_function :SetupComm,       [:pointer, :uint32, :uint32], :int32, blocking: true

--- a/lib/rubyserial/windows_constants.rb
+++ b/lib/rubyserial/windows_constants.rb
@@ -1,6 +1,15 @@
 # Copyright (c) 2014-2016 The Hybrid Group
 
 module RubySerial
+  module WinC
+    extend FFI::Library
+    ffi_lib 'msvcrt'
+    ffi_convention :stdcall
+
+    attach_function :_open_osfhandle,     [:pointer, :int], :int, blocking: true
+    attach_function :_get_osfhandle,     [:int], :pointer, blocking: true
+  end
+
   module Win32
     extend FFI::Library
     ffi_lib 'kernel32'
@@ -277,13 +286,12 @@ module RubySerial
               :write_total_timeout_constant,    :uint32
     end
 
-    attach_function :CreateFileA,     [:pointer, :uint32, :uint32, :pointer, :uint32, :uint32, :pointer], :pointer, blocking: true
-    attach_function :CloseHandle,     [:pointer], :int, blocking: true
-    attach_function :ReadFile,        [:pointer, :pointer, :uint32, :pointer, :pointer], :int32, blocking: true
-    attach_function :WriteFile,       [:pointer, :pointer, :uint32, :pointer, :pointer], :int32, blocking: true
+    attach_function :SetupComm,       [:pointer, :uint32, :uint32], :int32, blocking: true
     attach_function :GetCommState,    [:pointer, RubySerial::Win32::DCB], :int32, blocking: true
     attach_function :SetCommState,    [:pointer, RubySerial::Win32::DCB], :int32, blocking: true
     attach_function :GetCommTimeouts, [:pointer, RubySerial::Win32::CommTimeouts], :int32, blocking: true
     attach_function :SetCommTimeouts, [:pointer, RubySerial::Win32::CommTimeouts], :int32, blocking: true
+    # TODO, expose this?
+    attach_function :EscapeCommFunction,       [:pointer, :uint32], :int32, blocking: true
   end
 end

--- a/lib/rubyserial/windows_constants.rb
+++ b/lib/rubyserial/windows_constants.rb
@@ -5,6 +5,9 @@
 module RubySerial
   # @api private
   # @!visibility private
+  ENOTTY_MAP="ENOTTY"
+  # @api private
+  # @!visibility private
   module WinC
     extend FFI::Library
     ffi_lib 'msvcrt'

--- a/spec/arduino.ino
+++ b/spec/arduino.ino
@@ -1,0 +1,91 @@
+// This is the Arduino script for testing. Please compile and upload to any arduino with *hardware* serial. SoftSerial doesn't reset on HUPCL, such as with the pro Mini.
+// Uno, Nano, or other board with ftdi or similar usb chips are required.
+
+int i = 0;
+int loopv = 0;
+void setup() {
+  // put your setup code here, to run once:
+ Serial.begin(57600);
+    Serial.write('z');
+    i = 0;
+    loopv = 0;
+}
+// w - wait 250ms
+// e immediate "echo!"
+// n immediate "narwhales are cool"
+// i immediate "A" + i++
+// a[5 bytes] - immediate 5 byte echo
+// [1s wait] - "y/w"
+// x/y - enable/disable pings
+// r - reset i
+
+bool ping = true;
+
+void loop()
+{
+  if (Serial.available())
+  {
+    char chr = (char)Serial.read();
+    switch (chr)
+    {
+      case 'a':
+        while (Serial.available() < 5)
+          delay(3);
+        byte buf[5];
+        Serial.readBytes(buf, 5);
+        Serial.write(buf, 5);
+        break;
+      case 'b':
+      {
+        while (Serial.available() < 5)
+          delay(3);
+        int buf2;
+        Serial.readBytes((char*)&buf2, 4);
+        uint8_t r = Serial.read();
+        Serial.end();
+        delay(100);
+        Serial.begin(buf2, r);
+        delay(100);
+        Serial.write('B');
+        break;
+      }
+      case 'e':
+        Serial.print("echo");
+        break;
+      case 'w':
+        delay(250);
+        break;
+      case 'i':
+        Serial.write(i++ + 'A');
+        break;
+      case 'n':
+        Serial.print("narwhales are cool");
+        break;
+      case 'y':
+        ping = false;
+        break;
+      case 'x':
+        ping = true;
+        break;
+      case 'r':
+        i = 0;
+        break;
+      default:
+        Serial.write('!');
+        break;
+    }
+    loopv = 0;
+  }
+  loopv++;
+  if (loopv == 1000 && ping)
+  {
+    Serial.write('w');
+  }
+  else if (loopv == 2000 && ping)
+  {
+    Serial.write('y');
+    loopv = 0;
+  }
+  delay(1);
+}
+

--- a/spec/rubyserial_spec.rb
+++ b/spec/rubyserial_spec.rb
@@ -1,4 +1,5 @@
 require 'rubyserial'
+require 'timeout'
 
 describe "rubyserial" do
   before do
@@ -62,71 +63,91 @@ describe "rubyserial" do
   end
 
   it "reading nothing should be blank" do
-    expect(@sp.read(5)).to eql('')
+	Timeout::timeout(3) do
+      expect(@sp.read(5)).to eql('')
+    end
   end
 
   it "should give me nil on getbyte" do
-    expect(@sp.getbyte).to be_nil
+    Timeout::timeout(3) do
+      expect(@sp.getbyte).to be_nil
+    end
   end
 
   it 'should give me a zero byte from getbyte' do
-    @sp2.write("\x00")
-    sleep 0.1
-    expect(@sp.getbyte).to eql(0)
+	Timeout::timeout(3) do
+      @sp2.write("\x00")
+      sleep 0.1
+      expect(@sp.getbyte).to eql(0)
+    end
   end
 
   it "should give me bytes" do
-    @sp2.write('hello')
-    # small delay so it can write to the other port.
-    sleep 0.1
-    check = @sp.getbyte
-    expect([check].pack('C')).to eql('h')
+	Timeout::timeout(3) do
+      @sp2.write('hello')
+      # small delay so it can write to the other port.
+      sleep 0.1
+      check = @sp.getbyte
+      expect([check].pack('C')).to eql('h')
+    end
   end
 
   describe "giving me lines" do
     it "should give me a line" do
-      @sp.write("no yes \n hello")
-      sleep 0.1
-      expect(@sp2.gets).to eql("no yes \n")
+      Timeout::timeout(3) do
+        @sp.write("no yes \n hello")
+        sleep 0.1
+        expect(@sp2.gets).to eql("no yes \n")
+      end
     end
 
     it "should give me a line with block" do
-      @sp.write("no yes \n hello")
-      sleep 0.1
-      result = ""
-      @sp2.gets do |line|
-        result = line
-        break if !result.empty?
+      Timeout::timeout(3) do
+        @sp.write("no yes \n hello")
+        sleep 0.1
+        result = ""
+        @sp2.gets do |line|
+          result = line
+          break if !result.empty?
+        end
+        expect(result).to eql("no yes \n")
       end
-      expect(result).to eql("no yes \n")
     end
 
     it "should accept a sep param" do
-      @sp.write('no yes END bleh')
-      sleep 0.1
-      expect(@sp2.gets('END')).to eql("no yes END")
+      Timeout::timeout(3) do
+        @sp.write('no yes END bleh')
+        sleep 0.1
+        expect(@sp2.gets('END')).to eql("no yes END")
+      end
     end
 
     it "should accept a limit param" do
-      @sp.write("no yes \n hello")
-      sleep 0.1
-      expect(@sp2.gets(4)).to eql("no y")
+	  Timeout::timeout(3) do
+        @sp.write("no yes \n hello")
+        sleep 0.1
+        expect(@sp2.gets(4)).to eql("no y")
+      end
     end
 
     it "should accept limit and sep params" do
-      @sp.write("no yes END hello")
-      sleep 0.1
-      expect(@sp2.gets('END', 20)).to eql("no yes END")
-      @sp2.read(1000)
-      @sp.write("no yes END hello")
-      sleep 0.1
-      expect(@sp2.gets('END', 4)).to eql('no y')
+	  Timeout::timeout(3) do
+        @sp.write("no yes END hello")
+        sleep 0.1
+        expect(@sp2.gets('END', 20)).to eql("no yes END")
+        @sp2.read(1000)
+        @sp.write("no yes END hello")
+        sleep 0.1
+        expect(@sp2.gets('END', 4)).to eql('no y')
+      end
     end
 
     it "should read a paragraph at a time" do
-      @sp.write("Something \n Something else \n\n and other stuff")
-      sleep 0.1
-      expect(@sp2.gets('')).to eql("Something \n Something else \n\n")
+	  Timeout::timeout(3) do
+        @sp.write("Something \n Something else \n\n and other stuff")
+        sleep 0.1
+        expect(@sp2.gets('')).to eql("Something \n Something else \n\n")
+      end
     end
   end
 

--- a/spec/rubyserial_spec.rb
+++ b/spec/rubyserial_spec.rb
@@ -172,7 +172,7 @@ describe "rubyserial" do
       @sp.close
       rate = 600
       @sp = Serial.new(@ports[1], rate)
-      fd = @sp.instance_variable_get(:@fd)
+      fd = @sp.send :fd
       module RubySerial
         module Posix
           attach_function :tcgetattr, [ :int, RubySerial::Posix::Termios ], :int, blocking: true
@@ -180,7 +180,7 @@ describe "rubyserial" do
       end
       termios = RubySerial::Posix::Termios.new
       RubySerial::Posix::tcgetattr(fd, termios)
-      expect(termios[:c_ispeed]).to eql(RubySerial::Posix::BAUDE_RATES[rate])
+      expect(termios[:c_ispeed]).to eql(RubySerial::Posix::BAUD_RATES[rate])
     end
   end
 end

--- a/spec/rubyserial_spec.rb
+++ b/spec/rubyserial_spec.rb
@@ -15,7 +15,7 @@ describe "rubyserial" do
       raise 'socat not found' unless (`socat -h` && $? == 0)
 
       Thread.new do
-        system('socat -lf socat.log -d -d pty,raw,echo=0 pty,raw,echo=0')
+        @pid = spawn('socat -lf socat.log -d -d pty,raw,echo=0 pty,raw,echo=0')
       end
 
       @ptys = nil
@@ -42,28 +42,35 @@ describe "rubyserial" do
   after do
    @sp2.close
    @sp.close
+   Process.kill "KILL", @pid
   end
 
   it "should read and write" do
-    @sp2.write('hello')
-    # small delay so it can write to the other port.
-    sleep 0.1
-    check = @sp.read(5)
-    expect(check).to eql('hello')
+    Timeout::timeout(3) do
+      @sp2.write('hello')
+      # small delay so it can write to the other port.
+      sleep 0.1
+      check = @sp.read(5)
+      expect(check).to eql('hello')
+    end
   end
 
   it "should convert ints to strings" do
-    expect(@sp2.write(123)).to eql(3)
-    sleep 0.1
-    expect(@sp.read(3)).to eql('123')
+    Timeout::timeout(3) do
+      expect(@sp2.write(123)).to eql(3)
+      sleep 0.1
+      expect(@sp.read(3)).to eql('123')
+    end
   end
 
   it "write should return bytes written" do
-    expect(@sp2.write('hello')).to eql(5)
+    Timeout::timeout(3) do
+      expect(@sp2.write('hello')).to eql(5)
+    end
   end
 
   it "reading nothing should be blank" do
-	Timeout::timeout(3) do
+    Timeout::timeout(3) do
       expect(@sp.read(5)).to eql('')
     end
   end

--- a/spec/rubyserial_spec.rb
+++ b/spec/rubyserial_spec.rb
@@ -173,11 +173,6 @@ describe "rubyserial" do
       rate = 600
       @sp = Serial.new(@ports[1], rate)
       fd = @sp.send :fd
-      module RubySerial
-        module Posix
-          attach_function :tcgetattr, [ :int, RubySerial::Posix::Termios ], :int, blocking: true
-        end
-      end
       termios = RubySerial::Posix::Termios.new
       RubySerial::Posix::tcgetattr(fd, termios)
       expect(termios[:c_ispeed]).to eql(RubySerial::Posix::BAUD_RATES[rate])

--- a/spec/rubyserial_spec.rb
+++ b/spec/rubyserial_spec.rb
@@ -9,6 +9,7 @@ describe "rubyserial" do
       # https://github.com/hybridgroup/rubyserial/raw/appveyor_deps/setup_com0com_W7_x64_signed.exe
       @ports[0] = "\\\\.\\CNCA0"
       @ports[1] = "\\\\.\\CNCB0"
+      @pid = nil
     else
       File.delete('socat.log') if File.file?('socat.log')
 
@@ -42,7 +43,7 @@ describe "rubyserial" do
   after do
    @sp2.close
    @sp.close
-   Process.kill "KILL", @pid
+   Process.kill "KILL", @pid unless @pid.nil?
   end
 
   it "should read and write" do
@@ -98,7 +99,6 @@ describe "rubyserial" do
       expect([check].pack('C')).to eql('h')
     end
   end
-
   describe "giving me lines" do
     it "should give me a line" do
       Timeout::timeout(3) do

--- a/spec/serial_arduino_spec.rb
+++ b/spec/serial_arduino_spec.rb
@@ -1,3 +1,5 @@
+# Copyright (c) 2019 Patrick Plenefisch
+
 require 'rubyserial'
 require 'timeout'
 
@@ -9,13 +11,17 @@ describe "serialport" do
     else
       @port = "/dev/ttyUSB0"# SerialPort
     end
-
-    @ser = SerialPort.new(@port, 57600, 8, 1, :none)
+    @ser = nil
+    begin
+      @ser = SerialPort.new(@port, 57600, 8, 1, :none)
+    rescue Errno::ENOENT
+      skip "Arduino not connected or port number wrong"
+    end
   end
   NAR = "narwhales are cool"
 
   after do
-   @ser.close
+   @ser.close if @ser
   end
 
 	it "should have the arduino" do

--- a/spec/serial_arduino_spec.rb
+++ b/spec/serial_arduino_spec.rb
@@ -9,6 +9,7 @@ describe "serialport" do
     if RubySerial::ON_WINDOWS
       @port = "COM3"
     else
+      # cu.usbserial-???? on a mac (varies)
       @port = "/dev/ttyUSB0"# SerialPort
     end
     @ser = nil
@@ -88,7 +89,7 @@ describe "serialport" do
 			@ser.close # stil resets
 			@ser = SerialPort.new(@port, 57600, 8, 1, :none) # reopen with hupcl set
 			
-			sleep 0.25
+			sleep 0.75 # time for the arduino to reset
 			@ser.readpartial(1024) # remove the z
 			
 			@ser.close # should NOT reset

--- a/spec/serial_arduino_spec.rb
+++ b/spec/serial_arduino_spec.rb
@@ -229,6 +229,7 @@ describe "serialport" do
 	
 	it "should support changing settings" do
 		Timeout::timeout(12) do
+			sleep 0.1
 			expect(@ser.read(1)).to eq("z")
 			@ser.puts "ye"
 			@ser.hupcl = false

--- a/spec/serial_arduino_spec.rb
+++ b/spec/serial_arduino_spec.rb
@@ -1,0 +1,274 @@
+require 'rubyserial'
+require 'timeout'
+
+describe "serialport" do
+  before do
+    @ports = []
+    if RubySerial::ON_WINDOWS
+      @port = "COM3"
+    else
+      @port = "/dev/ttyUSB0"# SerialPort
+    end
+
+    @ser = SerialPort.new(@port, 57600, 8, 1, :none)
+  end
+  NAR = "narwhales are cool"
+
+  after do
+   @ser.close
+  end
+
+	it "should have the arduino" do
+		Timeout::timeout(3) do
+		#@ser.dtr = true
+			dat = @ser.read(1)
+			expect(dat).not_to be_nil
+			expect(dat.length).to be(1)
+			expect(['z', 'w', 'y']).to include(dat)
+		end
+	end
+	it "should read all" do
+		sleep 3.2 # ensure some data exists
+		Timeout::timeout(1) do
+			dat = @ser.readpartial(1024)
+			expect(dat).not_to be_nil
+			expect(dat.length).to be >= 2
+			expect(dat.length).to be <= 512
+		end
+	end
+=begin
+	it "should test" do
+		puts "start"
+		#@ser.dtr = true
+		p @ser.read(1)
+		p @ser.read(1)
+		p "dtr = false"
+		#@ser.dtr = false
+		p @ser.write("e")
+		p @ser.read(1)
+		p @ser.read(1)
+		p @ser.read(1)
+		p @ser.read(1)
+		p "dtr = true"
+		#@ser.dtr = true
+		p @ser.read(1)
+		p @ser.read(1)
+		p @ser.read(1)
+		p @ser.read(1)
+		p "dtr = false"
+		#@ser.dtr = false
+		p @ser.read(1)
+		p @ser.read(1)
+		p @ser.read(1)
+		p @ser.read(1)
+	end
+=end
+	it "should reset" do
+		@ser.hupcl = true
+		@ser.read_nonblock(1024) rescue nil # remove the old garbage if it exists
+		@ser.close
+		@ser = SerialPort.new(@port, 57600, 8, 1, :none)
+		Timeout::timeout(3) do
+			dat = @ser.read(1)
+			dat = @ser.read(1) if /[wy]/ === dat
+			expect(dat).to eq("z")
+		end
+	end
+	
+	
+	it "should not reset" do
+		Timeout::timeout(4) do
+			@ser.hupcl = false
+			@ser.close # stil resets
+			@ser = SerialPort.new(@port, 57600, 8, 1, :none) # reopen with hupcl set
+			
+			sleep 0.25
+			@ser.readpartial(1024) # remove the z
+			
+			@ser.close # should NOT reset
+			@ser = SerialPort.new(@port, 57600, 8, 1, :none)
+			expect(@ser.read(1)).not_to eq("z")
+		end
+	end
+
+	it "should write" do
+		Timeout::timeout(2) do
+			@ser.write "iy"
+			@ser.flush
+			@ser.readpartial(1024) # remove the z
+			
+			@ser << "ex"
+			
+			dat = @ser.read(4)
+			expect(dat).not_to be_nil
+			expect(dat).to eq("echo")
+		end
+	end
+	
+	it "should timeout" do
+		#expect(@ser.readpartial(1024)).to end_with("z")
+		Timeout::timeout(2) do
+			@ser.write "a12345"
+			dat = @ser.readpartial(1024)
+			expect(dat).not_to be_nil
+			expect(dat).to end_with("12345")
+		end
+	end
+	it "should capture partial" do
+		#expect(@ser.readpartial(1024)).to end_with("z")
+		Timeout::timeout(2) do
+			@ser.write "riiwwwwa12345"
+			dat = @ser.readpartial(1024)
+			expect(dat).not_to be_nil
+			expect(dat).to end_with("AB")
+			
+			dat = @ser.readpartial(1024)
+			expect(dat).not_to be_nil
+			expect(dat).to eq("12345")
+		end
+	end
+	it "should wait" do
+		#expect(@ser.readpartial(1024)).to end_with("z")
+		Timeout::timeout(2) do
+			@ser.write "riwewwwwa98765"
+			dat = @ser.readpartial(1024) # remove the A
+			expect(dat).not_to be_nil
+			expect(dat).to end_with("A")
+			
+			dat = @ser.read(9)
+			expect(dat).not_to be_nil
+			expect(dat).to eq("echo98765")
+		end
+	end
+
+	it "should reset (with write)" do
+		Timeout::timeout(4) do
+			@ser.hupcl = true
+			@ser.write_nonblock("eiiiny")
+			sleep 0.1
+			@ser.readpartial(1024) # remove the garbage
+			@ser.close
+			@ser = SerialPort.new(@port, 57600, 8, 1, :none)
+			
+			expect(@ser.read(1)).to eq("z")
+			expect(@ser.write_nonblock("iiiiir")).to eq(6)
+			expect(@ser.read(3)).to eq("ABC")
+		end
+	end
+	
+	
+	it "should not reset (with write)" do
+		Timeout::timeout(4) do
+			@ser.hupcl = false
+			@ser.close # stil resets
+			@ser = SerialPort.new(@port, 57600, 8, 1, :none) # reopen with hupcl set
+			@ser.write "ey"
+			sleep 1
+			@ser.readpartial(1024) # remove the z
+			@ser << "riin"
+			@ser.flush # windows flush???
+			sleep 0.1
+			dat = @ser.read_nonblock(2 + NAR.length)
+			expect(dat).to eq("AB#{NAR}")
+			
+			@ser.close # should NOT reset
+			@ser = SerialPort.new(@port, 57600, 8, 1, :none)
+			@ser << "ie"
+			sleep 0.1
+			expect(@ser.readpartial(1024)).to eq("Cecho")
+			@ser.hupcl = true
+		end
+	end
+	
+	
+	it "should support changing baud" do
+		Timeout::timeout(6) do
+			expect(@ser.read(1)).to eq("z")
+			@ser.puts "ye"
+			@ser.hupcl = true
+			sleep 0.1
+			dat = @ser.readpartial(1024)
+			if dat.end_with? "echo!!"
+				expect(dat).to end_with("echo!!") # mri on windows
+			else
+				expect(dat).to end_with("echo!")
+			end
+			
+			@ser.print ["b", 19200, 6].pack("aVC")
+			@ser.flush
+			sleep 0.150 # wait for new baud to appear
+			@ser.baud = 19200
+			#sleep 1
+			#p @ser.readpartial(NAR.length)
+			expect(@ser.read(1)).to eq("B")
+			@ser << "n"
+			sleep 0.1
+			dat = @ser.readpartial(NAR.length)
+			expect(dat).to eq(NAR)
+			
+			
+			@ser.print ["b", 9600, 6].pack("aVC")
+			@ser.flush
+			sleep 0.150 # wait for new baud to appear
+			@ser.baud = 9600
+			expect(@ser.read(1)).to eq("B")
+			@ser << "e"
+			sleep 0.1
+			dat = @ser.readpartial(5)
+			expect(dat).to eq("echo")
+		end
+	end
+	
+	
+	it "should support changing settings" do
+		Timeout::timeout(12) do
+			expect(@ser.read(1)).to eq("z")
+			@ser.puts "ye"
+			@ser.hupcl = false
+			sleep 0.5
+			dat = @ser.readpartial(1024)
+			if dat.end_with? "echo!!"
+				expect(dat).to end_with("echo!!") # mri on windows
+			else
+				expect(dat).to end_with("echo!")
+			end
+			
+			@ser.print ["b", 19200, 0x2e].pack("aVC")
+			@ser.flush
+			sleep 0.050 # wait for new baud to appear
+			@ser.baud = 19200
+			@ser.data_bits = 8
+			@ser.parity = :even
+			expect(@ser.stop_bits = 2).to eq(2)
+			#sleep 1
+			#p @ser.readpartial(NAR.length)
+			expect(@ser.read(1)).to eq("B")
+			@ser << "n"
+			sleep 0.1
+			dat = @ser.readpartial(NAR.length)
+			expect(dat).to eq(NAR)
+			
+			
+			@ser.print ["b", 19200, 0x34].pack("aVC")
+			@ser.flush
+			sleep 0.050 # wait for new baud to appear
+			@ser.baud = 19200
+			@ser.data_bits = 7
+			@ser.parity = :odd
+			@ser.stop_bits = 1
+			expect(@ser.read(1)).to eq("B")
+			@ser << "e"
+			sleep 0.1
+			dat = @ser.readpartial(5)
+			expect(dat).to eq("echo")
+		end
+	end
+
+	it "should be inspectable" do
+		@ser.hupcl = true
+		expect(@ser.to_s).to start_with "#<SerialPort:0x"
+		expect(@ser.inspect).to start_with "#<SerialPort:fd "
+		@ser << "x" # reset so that the first tests work
+	end
+
+end

--- a/spec/serial_arduino_spec.rb
+++ b/spec/serial_arduino_spec.rb
@@ -6,12 +6,8 @@ require 'timeout'
 describe "serialport" do
   before do
     @ports = []
-    if RubySerial::ON_WINDOWS
-      @port = "COM3"
-    else
-      # cu.usbserial-???? on a mac (varies)
-      @port = "/dev/ttyUSB0"# SerialPort
-    end
+    @port = ENV['RS_ARDUINO_PORT']
+    skip "RS_ARDUINO_PORT is undefined. Please define it to be the port that the arduino program is attached if you wish to test hupcl behavior." if @port.nil?
     @ser = nil
     begin
       @ser = SerialPort.new(@port, 57600, 8, 1, :none)
@@ -43,33 +39,7 @@ describe "serialport" do
 			expect(dat.length).to be <= 512
 		end
 	end
-=begin
-	it "should test" do
-		puts "start"
-		#@ser.dtr = true
-		p @ser.read(1)
-		p @ser.read(1)
-		p "dtr = false"
-		#@ser.dtr = false
-		p @ser.write("e")
-		p @ser.read(1)
-		p @ser.read(1)
-		p @ser.read(1)
-		p @ser.read(1)
-		p "dtr = true"
-		#@ser.dtr = true
-		p @ser.read(1)
-		p @ser.read(1)
-		p @ser.read(1)
-		p @ser.read(1)
-		p "dtr = false"
-		#@ser.dtr = false
-		p @ser.read(1)
-		p @ser.read(1)
-		p @ser.read(1)
-		p @ser.read(1)
-	end
-=end
+
 	it "should reset" do
 		@ser.hupcl = true
 		@ser.read_nonblock(1024) rescue nil # remove the old garbage if it exists
@@ -81,8 +51,7 @@ describe "serialport" do
 			expect(dat).to eq("z")
 		end
 	end
-	
-	
+
 	it "should not reset" do
 		Timeout::timeout(4) do
 			@ser.hupcl = false

--- a/spec/serialport_spec.rb
+++ b/spec/serialport_spec.rb
@@ -6,12 +6,12 @@ require 'timeout'
 describe "serialport api" do
   before do
     @ports = []
+    @port = ENV['RS_TEST_PORT'] || ENV['RS_ARDUINO_PORT']
+    skip "RS_TEST_PORT is undefined. Please define it (or RS_ARDUINO_PORT) to any valid serial port" if @port.nil?
     if RubySerial::ON_WINDOWS
-      @port = "COM1" #TODO...
       @not_a_port = nil
     else
       # Use ttys0 on a mac
-      @port = "/dev/ttyS0"# SerialPort
       @not_a_port = "/dev/null"
       @not_a_file = "/dev/not_a_file"
     end

--- a/spec/serialport_spec.rb
+++ b/spec/serialport_spec.rb
@@ -10,6 +10,7 @@ describe "serialport api" do
       @port = "COM1" #TODO...
       @not_a_port = nil
     else
+      # Use ttys0 on a mac
       @port = "/dev/ttyS0"# SerialPort
       @not_a_port = "/dev/null"
       @not_a_file = "/dev/not_a_file"
@@ -44,7 +45,7 @@ describe "serialport api" do
 		expect {
 			s = Serial.new(@not_a_port)
 			s.close
-		}.to raise_error(RubySerial::Error, "ENOTTY")
+		}.to raise_error(RubySerial::Error, /^ENO/)
 		
 		expect {
 			s = Serial.new(@not_a_file)
@@ -79,8 +80,6 @@ describe "serialport api" do
 	
 	it "should support open named args" do
 		SerialPort.open(@port, "baud" => 57600,  "data_bits" => 6, "stop_bits" => 1, "parity" => :even) do |s|
-			p s
-			p s.to_s
 			expect(s.baud).to eq 57600
 			expect(s.data_bits).to eq 6
 			expect(s.stop_bits).to eq 1

--- a/spec/serialport_spec.rb
+++ b/spec/serialport_spec.rb
@@ -1,0 +1,140 @@
+# Copyright (c) 2019 Patrick Plenefisch
+
+require 'rubyserial'
+require 'timeout'
+
+describe "serialport api" do
+  before do
+    @ports = []
+    if RubySerial::ON_WINDOWS
+      @port = "COM1" #TODO...
+      @not_a_port = nil
+    else
+      @port = "/dev/ttyS0"# SerialPort
+      @not_a_port = "/dev/null"
+      @not_a_file = "/dev/not_a_file"
+    end
+  end
+
+	it "should support new" do
+		s = SerialPort.new(@port)
+		expect(s.closed?).to be false
+		expect(s.name).to eq @port
+		expect(s).to be_an IO
+		s.close
+		expect(s.closed?).to be true
+	end
+	
+	it "should only support serial ports" do
+		skip "Not supported on windows" if @not_a_port.nil?
+		expect {
+			s = SerialPort.new(@not_a_port)
+			s.close
+		}.to raise_error(ArgumentError, "not a serial port")
+		
+		expect {
+			s = SerialPort.new(@not_a_file)
+			s.close
+		}.to raise_error(Errno::ENOENT, /No such file or directory .*- #{@not_a_file}/)
+	end
+	
+	
+	it "should only support serial ports (serial API)" do
+		skip "Not supported on windows" if @not_a_port.nil?
+		expect {
+			s = Serial.new(@not_a_port)
+			s.close
+		}.to raise_error(RubySerial::Error, "ENOTTY")
+		
+		expect {
+			s = Serial.new(@not_a_file)
+			s.close
+		}.to raise_error(Errno::ENOENT, /No such file or directory .*- #{@not_a_file}/)
+	end
+	
+	it "should support named args" do
+		s = SerialPort.new(@port, "baud" => 9600, "data_bits" => 8)
+		expect(s.baud).to eq 9600
+		expect(s.data_bits).to eq 8
+		s.close
+	end
+	it "should support open" do
+		outers = nil
+		SerialPort.open(@port) do |s|
+			outers = s
+			expect(s.closed?).to be false
+			expect(s.name).to eq @port
+			expect(s).to be_an IO
+		end
+		expect(outers.closed?).to be true
+	end
+	it "should support open args" do
+		SerialPort.open(@port, 19200, 7, 2, :odd) do |s|
+			expect(s.baud).to eq 19200
+			expect(s.data_bits).to eq 7
+			expect(s.stop_bits).to eq 2
+			expect(s.parity).to eq :odd
+		end
+	end
+	
+	it "should support open named args" do
+		SerialPort.open(@port, "baud" => 57600,  "data_bits" => 6, "stop_bits" => 1, "parity" => :even) do |s|
+			p s
+			p s.to_s
+			expect(s.baud).to eq 57600
+			expect(s.data_bits).to eq 6
+			expect(s.stop_bits).to eq 1
+			expect(s.parity).to eq :even
+		end
+	end
+	
+	it "should support changing values" do
+		SerialPort.open(@port, "baud" => 9600,  "data_bits" => 7, "stop_bits" => 2, "parity" => :odd) do |s|
+			expect(s.baud).to eq 9600
+			expect(s.data_bits).to eq 7
+			expect(s.stop_bits).to eq 2
+			expect(s.parity).to eq :odd
+			
+			expect(s.baud=19200).to eq 19200
+			expect(s.baud).to eq 19200
+			expect(s.data_bits).to eq 7
+			expect(s.stop_bits).to eq 2
+			expect(s.parity).to eq :odd
+			
+			expect(s.data_bits=8).to eq 8
+			expect(s.baud).to eq 19200
+			expect(s.data_bits).to eq 8
+			expect(s.stop_bits).to eq 2
+			expect(s.parity).to eq :odd
+			
+			expect(s.parity=:none).to eq :none
+			expect(s.baud).to eq 19200
+			expect(s.data_bits).to eq 8
+			expect(s.stop_bits).to eq 2
+			expect(s.parity).to eq :none
+			
+			expect(s.stop_bits=1).to eq 1
+			expect(s.baud).to eq 19200
+			expect(s.data_bits).to eq 8
+			expect(s.stop_bits).to eq 1
+			expect(s.parity).to eq :none
+		end
+	end
+	
+	it "should support hupcl" do
+		SerialPort.open(@port) do |s|
+			expect(s.hupcl = true).to eq true
+			expect(s.hupcl).to eq true
+			s.baud=19200 # re-get the values
+			expect(s.hupcl).to eq true 
+			expect(s.hupcl = false).to eq false
+			expect(s.hupcl).to eq false
+			s.baud=9600 # re-get the values
+			expect(s.hupcl).to eq false
+			expect(s.hupcl = true).to eq true
+			expect(s.hupcl).to eq true
+			s.baud=19200 # re-get the values
+			expect(s.hupcl).to eq true 
+		end
+	end
+end


### PR DESCRIPTION
(Note this PR is still WIP, and should NOT be merged until this check list is finished)

- [x] Wait for JRuby 9.2.9.0 to be released
- [x] Test on Mac OS X
- [x] Upload Arduino test spec for HUPCL tests
- [x] Fix API test spec to work on CI

This PR ditches the FFI calls to open & close in favor of using IO::for_fd so that we can use normal IO blocking & nonblocking methods. It still requires a bit of funkyness on windows, but it is working with MRI, and JRuby 9.2.8.0.dev + patches. This will fix #25 for the blocking, and will fix #36 as IO#flush works correctly out of the box now.

As part of this, I did some clean up of the API, and unfortunately this has some breaking changes for exceptions and return types. I went the safe way to minimize harm, but I still bumped the version to be cautious. Not sure if that's a good idea or not? Feedback greatly appreciated on that.

Third, I added lots of yard doc to all methods. 

Fourth, I added a SerialPort class that enables compatibility on par with what the readme suggested already existed, but didn't quite. 

Fifth, I added support for the HUPCL flag (Windows via `DtrControl`) to fix #15. `Serial#reconfigure(hupcl: true|false)` or `SerialPort#hupcl= true|false`

Sixth, I added a bunch more tests for HUPCL & general API stuff. Unfortunately I couldn't figure out a way to do this without a second program, so 1/3 of the tests now depend on an arduino project, though they are skipped if not detected. 

That's all for now. The patches for JRuby are jnr/jnr-enxio:master and https://github.com/jruby/jruby/pull/5774 branch https://github.com/byteit101/jruby/tree/winio)